### PR TITLE
[Feature] Follow 기능 구현 및 통합 테스트 작성

### DIFF
--- a/src/main/java/synapps/resona/api/global/config/SwaggerConfig.java
+++ b/src/main/java/synapps/resona/api/global/config/SwaggerConfig.java
@@ -26,8 +26,8 @@ public class SwaggerConfig {
 
         return new OpenAPI()
                 .info(new Info()
-                        .title("전세계 채팅 프로젝트 유저 API")
-                        .description("유저, sns 기본 기능들이 있습니다.")
+                        .title("Resona SNS Server API")
+                        .description("Provides SNS, Member APIs")
                         .version("1.0.0"))
                 .components(new Components().addSecuritySchemes("bearerAuth", securityScheme))
                 .security(List.of(securityRequirement))

--- a/src/main/java/synapps/resona/api/global/exception/ErrorCode.java
+++ b/src/main/java/synapps/resona/api/global/exception/ErrorCode.java
@@ -13,6 +13,7 @@ public enum ErrorCode {
     INVALID_PASSWORD(HttpStatus.UNAUTHORIZED, "MEM003", "Invalid password"),
     INVALID_TIMESTAMP(HttpStatus.UNAUTHORIZED, "MEM004", "Invalid timestamp"),
     UNAUTHENTICATED_REQUEST(HttpStatus.FORBIDDEN, "MEM005", "Forbidden approach"),
+    FOLLOWING_NOT_FOUND(HttpStatus.NOT_FOUND, "MEM006", "Member trying to Follow is Not found"),
 
     // auth
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH001", "Invalid token"),
@@ -44,8 +45,12 @@ public enum ErrorCode {
 
     // member details
     MEMBER_DETAILS_NOT_FOUND(HttpStatus.NOT_FOUND, "MDETAILS001", "Member Details not found"),
-
     TIMESTAMP_INVALID(HttpStatus.CONFLICT, "TIMESTAMP001", "Invalid timestamp"),
+
+    // follow
+    ALREADY_FOLLOWING(HttpStatus.CONFLICT, "FOLLOW001", "Already Following"),
+    FOLLOWING_MYSELF(HttpStatus.CONFLICT, "FOLLOW002", "Can't Follow myself"),
+    FOLLOW_RELATIONSHIP_NOT_FOUND(HttpStatus.NOT_FOUND, "FOLLOW003", "Can't find relationship"),
 
     // file
     FILE_EMPTY_EXCEPTION(HttpStatus.CONFLICT, "FILE001", "File is empty"),

--- a/src/main/java/synapps/resona/api/mysql/member/controller/FollowController.java
+++ b/src/main/java/synapps/resona/api/mysql/member/controller/FollowController.java
@@ -1,0 +1,78 @@
+package synapps.resona.api.mysql.member.controller;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import synapps.resona.api.global.config.server.ServerInfoConfig;
+import synapps.resona.api.global.dto.metadata.MetaDataDto;
+import synapps.resona.api.global.dto.response.ResponseDto;
+import synapps.resona.api.mysql.member.dto.response.MemberProfileDto;
+import synapps.resona.api.mysql.member.service.FollowService;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/follow")
+@RequiredArgsConstructor
+public class FollowController {
+
+    private final FollowService followService;
+    private final ServerInfoConfig serverInfo;
+
+    private MetaDataDto createSuccessMetaData(String queryString) {
+        return MetaDataDto.createSuccessMetaData(queryString, serverInfo.getApiVersion(), serverInfo.getServerName());
+    }
+
+    /**
+     * 로그인된 사용자가 특정 memberId를 팔로우함
+     */
+    @PostMapping("/{memberId}")
+    public ResponseEntity<?> follow(@PathVariable Long memberId,
+                                    HttpServletRequest request) {
+        followService.follow(memberId);
+
+        MetaDataDto metaData = createSuccessMetaData(request.getQueryString());
+        ResponseDto responseData = new ResponseDto(metaData, List.of("followed"));
+        return ResponseEntity.ok(responseData);
+    }
+
+    /**
+     * 로그인된 사용자가 특정 memberId를 언팔로우함
+     */
+    @DeleteMapping("/{memberId}")
+    public ResponseEntity<?> unfollow(@PathVariable Long memberId,
+                                      HttpServletRequest request) {
+        followService.unfollow(memberId);
+
+        MetaDataDto metaData = createSuccessMetaData(request.getQueryString());
+        ResponseDto responseData = new ResponseDto(metaData, List.of("unfollowed"));
+        return ResponseEntity.ok(responseData);
+    }
+
+    /**
+     * 특정 사용자의 팔로워 목록 조회
+     */
+    @GetMapping("/{memberId}/followers")
+    public ResponseEntity<?> getFollowers(@PathVariable Long memberId,
+                                          HttpServletRequest request) {
+        List<MemberProfileDto> followers = followService.getFollowers(memberId);
+
+        MetaDataDto metaData = createSuccessMetaData(request.getQueryString());
+        ResponseDto responseData = new ResponseDto(metaData, followers);
+        return ResponseEntity.ok(responseData);
+    }
+
+    /**
+     * 특정 사용자의 팔로잉 목록 조회
+     */
+    @GetMapping("/{memberId}/followings")
+    public ResponseEntity<?> getFollowings(@PathVariable Long memberId,
+                                           HttpServletRequest request) {
+        List<MemberProfileDto> followings = followService.getFollowings(memberId);
+
+        MetaDataDto metaData = createSuccessMetaData(request.getQueryString());
+        ResponseDto responseData = new ResponseDto(metaData, followings);
+        return ResponseEntity.ok(responseData);
+    }
+}

--- a/src/main/java/synapps/resona/api/mysql/member/dto/response/MemberProfileDto.java
+++ b/src/main/java/synapps/resona/api/mysql/member/dto/response/MemberProfileDto.java
@@ -1,0 +1,22 @@
+package synapps.resona.api.mysql.member.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.Getter;
+import synapps.resona.api.mysql.member.entity.member.Member;
+import synapps.resona.api.mysql.member.entity.profile.Profile;
+
+@Data
+@AllArgsConstructor
+@Getter
+public class MemberProfileDto {
+    private Long memberId;
+    private String profile_image_url;
+    private String nickname;
+    private String tag;
+
+
+    public static MemberProfileDto from(Member member, Profile profile) {
+        return new MemberProfileDto(member.getId(), profile.getProfileImageUrl(), profile.getNickname(), profile.getTag());
+    }
+}

--- a/src/main/java/synapps/resona/api/mysql/member/entity/member/Follow.java
+++ b/src/main/java/synapps/resona/api/mysql/member/entity/member/Follow.java
@@ -1,0 +1,34 @@
+package synapps.resona.api.mysql.member.entity.member;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import synapps.resona.api.global.entity.BaseEntity;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Follow extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "follow_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "follower_id")
+    private Member follower;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "following_id")
+    private Member following;
+
+    private Follow(Member follower, Member following) {
+        this.follower = follower;
+        this.following = following;
+    }
+
+    public static Follow of(Member follower, Member following) {
+        return new Follow(follower, following);
+    }
+}

--- a/src/main/java/synapps/resona/api/mysql/member/entity/member/Member.java
+++ b/src/main/java/synapps/resona/api/mysql/member/entity/member/Member.java
@@ -52,6 +52,12 @@ public class Member extends BaseEntity {
     @JoinColumn(name = "profile_id")
     private Profile profile;
 
+    @OneToMany(mappedBy = "follower")
+    private List<Follow> followings = new ArrayList<>();
+
+    @OneToMany(mappedBy = "following")
+    private List<Follow> followers = new ArrayList<>();
+
     @OneToMany(mappedBy = "member")
     private final List<Feed> feeds = new ArrayList<>();
 

--- a/src/main/java/synapps/resona/api/mysql/member/exception/FollowException.java
+++ b/src/main/java/synapps/resona/api/mysql/member/exception/FollowException.java
@@ -1,0 +1,27 @@
+package synapps.resona.api.mysql.member.exception;
+
+import org.springframework.http.HttpStatus;
+import synapps.resona.api.global.exception.BaseException;
+import synapps.resona.api.global.exception.ErrorCode;
+
+public class FollowException extends BaseException {
+    protected FollowException(String message, HttpStatus status, String errorCode) {
+        super(message, status, errorCode);
+    }
+
+    private static FollowException of(ErrorCode errorCode) {
+        return new FollowException(errorCode.getMessage(), errorCode.getStatus(), errorCode.getCode());
+    }
+
+    public static FollowException alreadyFollowing() {
+        return of(ErrorCode.ALREADY_FOLLOWING);
+    }
+
+    public static FollowException cantFollowMyself() {
+        return of(ErrorCode.FOLLOWING_MYSELF);
+    }
+
+    public static FollowException relationshipNotFound() {
+        return of(ErrorCode.FOLLOW_RELATIONSHIP_NOT_FOUND);
+    }
+}

--- a/src/main/java/synapps/resona/api/mysql/member/exception/MemberException.java
+++ b/src/main/java/synapps/resona/api/mysql/member/exception/MemberException.java
@@ -32,4 +32,8 @@ public class MemberException extends BaseException {
     public static MemberException unAuthenticatedRequest() {
         return of(ErrorCode.UNAUTHENTICATED_REQUEST);
     }
+
+    public static MemberException followingNotFound() {
+        return of(ErrorCode.FOLLOWING_NOT_FOUND);
+    }
 }

--- a/src/main/java/synapps/resona/api/mysql/member/repository/FollowRepository.java
+++ b/src/main/java/synapps/resona/api/mysql/member/repository/FollowRepository.java
@@ -1,0 +1,32 @@
+package synapps.resona.api.mysql.member.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+import synapps.resona.api.mysql.member.entity.member.Follow;
+import synapps.resona.api.mysql.member.entity.member.Member;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface FollowRepository extends JpaRepository<Follow, Long> {
+    boolean existsByFollowerAndFollowing(Member follower, Member following);
+    Optional<Follow> findByFollowerAndFollowing(Member follower, Member following);
+
+    @Query("SELECT DISTINCT f FROM Follow f " +
+            "JOIN FETCH f.following m " +
+            "JOIN FETCH m.profile " +
+            "WHERE f.follower.id = :memberId")
+    List<Follow> findFollowingsByFollowerId(@Param("memberId") Long memberId);
+
+    @Query("SELECT DISTINCT f FROM Follow f " +
+            "JOIN FETCH f.follower m " +
+            "JOIN FETCH m.profile " +
+            "WHERE f.following.id = :memberId")
+    List<Follow> findFollowersByFollowingId(@Param("memberId") Long memberId);
+
+    long countByFollower(Member follower);
+    long countByFollowing(Member following);
+}

--- a/src/main/java/synapps/resona/api/mysql/member/service/FollowService.java
+++ b/src/main/java/synapps/resona/api/mysql/member/service/FollowService.java
@@ -1,0 +1,70 @@
+package synapps.resona.api.mysql.member.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import synapps.resona.api.mysql.member.dto.response.MemberProfileDto;
+import synapps.resona.api.mysql.member.entity.member.Follow;
+import synapps.resona.api.mysql.member.entity.member.Member;
+import synapps.resona.api.mysql.member.exception.FollowException;
+import synapps.resona.api.mysql.member.exception.MemberException;
+import synapps.resona.api.mysql.member.repository.FollowRepository;
+import synapps.resona.api.mysql.member.repository.MemberRepository;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class FollowService {
+    private final FollowRepository followRepository;
+    private final MemberRepository memberRepository;
+    private final MemberService memberService;
+
+    public void follow(Long toMemberId) {
+        String email = memberService.getMemberEmail();
+        Member fromMember = memberRepository.findByEmail(email).orElseThrow(MemberException::memberNotFound);
+
+        if (fromMember.getId().equals(toMemberId)) {
+            throw FollowException.cantFollowMyself();
+        }
+
+        Member toMember = memberRepository.findById(toMemberId).orElseThrow(MemberException::followingNotFound);
+
+
+        boolean alreadyFollow = followRepository.existsByFollowerAndFollowing(fromMember, toMember);
+
+        if (alreadyFollow) {
+            throw FollowException.alreadyFollowing();
+        }
+
+
+        Follow follow = Follow.of(fromMember, toMember);
+        followRepository.save(follow);
+    }
+
+    public void unfollow(Long toMemberId) {
+        String email = memberService.getMemberEmail();
+        Member fromMember = memberRepository.findByEmail(email).orElseThrow(MemberException::memberNotFound);
+        Member toMember = memberRepository.findById(toMemberId).orElseThrow(MemberException::followingNotFound);
+
+        Follow follow = followRepository.findByFollowerAndFollowing(fromMember, toMember).orElseThrow(FollowException::relationshipNotFound);
+
+        followRepository.delete(follow);
+    }
+
+    public List<MemberProfileDto> getFollowers(Long memberId) {
+        return followRepository.findFollowersByFollowingId(memberId)
+                .stream()
+                .map(follow -> MemberProfileDto.from(follow.getFollower(), follow.getFollower().getProfile()))
+                .collect(Collectors.toList());
+    }
+
+    public List<MemberProfileDto> getFollowings(Long memberId) {
+        return followRepository.findFollowingsByFollowerId(memberId)
+                .stream()
+                .map(follow -> MemberProfileDto.from(follow.getFollowing(), follow.getFollowing().getProfile()))
+                .collect(Collectors.toList());
+    }
+}

--- a/src/test/java/synapps/resona/api/mysql/member/repository/FollowRepositoryTest.java
+++ b/src/test/java/synapps/resona/api/mysql/member/repository/FollowRepositoryTest.java
@@ -1,0 +1,147 @@
+package synapps.resona.api.mysql.member.repository;
+
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import synapps.resona.api.IntegrationTestSupport;
+import synapps.resona.api.mysql.member.entity.account.AccountInfo;
+import synapps.resona.api.mysql.member.entity.member.Follow;
+import synapps.resona.api.mysql.member.entity.member.Member;
+import synapps.resona.api.mysql.member.entity.member_details.MBTI;
+import synapps.resona.api.mysql.member.entity.member_details.MemberDetails;
+import synapps.resona.api.mysql.member.entity.profile.CountryCode;
+import synapps.resona.api.mysql.member.entity.profile.Language;
+import synapps.resona.api.mysql.member.entity.profile.Profile;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Transactional
+class FollowRepositoryTest extends IntegrationTestSupport {
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private FollowRepository followRepository;
+
+    private Member follower;
+    private Member following;
+
+    @BeforeEach
+    void setUp() {
+        follower = createMember("follower@example.com", "팔로워닉네임");
+        following = createMember("following@example.com", "팔로잉닉네임");
+
+        memberRepository.saveAll(List.of(follower, following));
+
+        Follow follow = Follow.of(follower, following);
+        followRepository.save(follow);
+    }
+
+
+    @Test
+    @DisplayName("멤버가 팔로우한 사람들의 프로필을 fetch join으로 조회한다.")
+    void findFollowingsByFollowerId() {
+        // when
+        List<Follow> followings = followRepository.findFollowingsByFollowerId(follower.getId());
+
+        // then
+        assertThat(followings).hasSize(1);
+        Follow result = followings.get(0);
+        assertThat(result.getFollowing().getEmail()).isEqualTo("following@example.com");
+        assertThat(result.getFollowing().getProfile().getNickname()).isEqualTo("팔로잉닉네임");
+    }
+
+    @Test
+    @DisplayName("멤버를 팔로우한 사람들의 프로필을 fetch join으로 조회한다.")
+    void findFollowersByFollowingId() {
+        // when
+        List<Follow> followers = followRepository.findFollowersByFollowingId(following.getId());
+
+        // then
+        assertThat(followers).hasSize(1);
+        Follow result = followers.get(0);
+        assertThat(result.getFollower().getEmail()).isEqualTo("follower@example.com");
+        assertThat(result.getFollower().getProfile().getNickname()).isEqualTo("팔로워닉네임");
+    }
+
+    @Test
+    @DisplayName("한 사람이 여러 명을 팔로우했을 때, 모든 following의 프로필을 fetch 한다")
+    void findFollowingsByFollowerId_multiple() {
+        // given
+        Member follower = createMember("followerMany@example.com", "팔로워닉네임");
+        Member another = createMember("another@example.com", "다른닉네임");
+        Member another2 = createMember("another2@example.com", "또다른닉네임");
+        memberRepository.saveAll(List.of(follower, another, another2));
+
+        followRepository.save(Follow.of(follower, another));
+        followRepository.save(Follow.of(follower, another2));
+
+        // when
+        List<Follow> followings = followRepository.findFollowingsByFollowerId(follower.getId());
+
+        // then
+        assertThat(followings).hasSize(2);
+        assertThat(followings).extracting(f -> f.getFollowing().getProfile().getNickname())
+                .containsExactlyInAnyOrder("다른닉네임", "또다른닉네임");
+    }
+
+    @Test
+    @DisplayName("여러 사람이 같은 사람을 팔로우했을 때, 모든 follower의 프로필을 fetch 한다")
+    void findFollowersByFollowingId_multiple() {
+        // given
+        Member following = createMember("followingMany@example.com", "팔로잉닉네임");
+        Member otherFollower1 = createMember("1@example.com", "팔로워1");
+        Member otherFollower2 = createMember("2@example.com", "팔로워2");
+        memberRepository.saveAll(List.of(following, otherFollower1, otherFollower2));
+
+        followRepository.save(Follow.of(otherFollower1, following));
+        followRepository.save(Follow.of(otherFollower2, following));
+
+        // when
+        List<Follow> followers = followRepository.findFollowersByFollowingId(following.getId());
+
+        // then
+        assertThat(followers).hasSize(2);
+        assertThat(followers).extracting(f -> f.getFollower().getProfile().getNickname())
+                .containsExactlyInAnyOrder("팔로워1", "팔로워2");
+    }
+
+    @Test
+    @DisplayName("서로 팔로우(맞팔) 관계도 정상 동작한다")
+    void mutualFollowTest() {
+        followRepository.save(Follow.of(follower, following)); // follower → following
+        followRepository.save(Follow.of(following, follower)); // following → follower
+
+        List<Follow> f1 = followRepository.findFollowingsByFollowerId(follower.getId());
+        List<Follow> f2 = followRepository.findFollowersByFollowingId(follower.getId());
+
+        assertThat(f1.get(0).getFollowing().getProfile().getNickname()).isEqualTo("팔로잉닉네임");
+        assertThat(f2.get(0).getFollower().getProfile().getNickname()).isEqualTo("팔로잉닉네임");
+    }
+
+
+
+
+    private Member createMember(String email, String nickname) {
+        AccountInfo accountInfo = AccountInfo.empty();
+        MemberDetails memberDetails = MemberDetails.of(0, "01011111111", MBTI.ENFJ, "about me", "location");
+        Profile profile = Profile.of(
+                CountryCode.KR,
+                CountryCode.KR,
+                Set.of(Language.KOREAN),
+                Set.of(Language.ENGLISH),
+                nickname,
+                "http://profile.img/" + nickname,
+                "2000-01-01"
+        );
+
+        return Member.of(accountInfo, memberDetails, profile, email, "password", LocalDateTime.now());
+    }
+}

--- a/src/test/java/synapps/resona/api/mysql/member/service/FollowServiceTest.java
+++ b/src/test/java/synapps/resona/api/mysql/member/service/FollowServiceTest.java
@@ -1,0 +1,145 @@
+package synapps.resona.api.mysql.member.service;
+
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.User;
+import synapps.resona.api.IntegrationTestSupport;
+import synapps.resona.api.mysql.member.dto.request.auth.RegisterRequest;
+import synapps.resona.api.mysql.member.dto.response.MemberProfileDto;
+import synapps.resona.api.mysql.member.entity.profile.CountryCode;
+import synapps.resona.api.mysql.member.entity.profile.Language;
+import synapps.resona.api.mysql.member.repository.FollowRepository;
+import synapps.resona.api.mysql.member.repository.MemberRepository;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Transactional
+class FollowServiceTest extends IntegrationTestSupport {
+
+    @Autowired private FollowService followService;
+    @Autowired private FollowRepository followRepository;
+    @Autowired private MemberRepository memberRepository;
+    @Autowired private MemberService memberService;
+
+    private final String loginEmail = "me@resona.com";
+
+    private Long meId;
+    private Long targetId;
+
+    @BeforeEach
+    void setUp() {
+        // 로그인한 사용자 등록
+        RegisterRequest me = new RegisterRequest(
+                loginEmail,
+                "secure123!",
+                CountryCode.KR,
+                CountryCode.KR,
+                Set.of(Language.KOREAN),
+                Set.of(Language.ENGLISH),
+                9,
+                "1998-07-21",
+                "나자신",
+                "http://image.me"
+        );
+
+        memberService.signUp(me);
+
+        // 상대 유저 등록
+        RegisterRequest other = new RegisterRequest(
+                "target@resona.com",
+                "secure123!",
+                CountryCode.KR,
+                CountryCode.KR,
+                Set.of(Language.KOREAN),
+                Set.of(Language.ENGLISH),
+                7,
+                "1995-01-01",
+                "상대방",
+                "http://image.you"
+        );
+        memberService.signUp(other);
+
+        meId = memberRepository.findByEmail(loginEmail).orElseThrow().getId();
+        targetId = memberRepository.findByEmail("target@resona.com").orElseThrow().getId();
+
+        // 로그인된 사용자 인증 정보 설정
+        User principal = new User(loginEmail, "", new ArrayList<>());
+        SecurityContextHolder.getContext().setAuthentication(
+                new UsernamePasswordAuthenticationToken(principal, null, principal.getAuthorities()));
+    }
+
+    @Test
+    @DisplayName("follow를 성공한다")
+    void follow_success() {
+        followService.follow(targetId);
+
+        assertThat(followRepository.existsByFollowerAndFollowing(
+                memberRepository.findById(meId).get(),
+                memberRepository.findById(targetId).get())
+        ).isTrue();
+    }
+
+    @Test
+    @DisplayName("unfollow를 성공한다")
+    void unfollow_success() {
+        followService.follow(targetId); // 먼저 팔로우하고
+
+        followService.unfollow(targetId);
+
+        assertThat(followRepository.findAll()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("팔로우한 목록을 조회할 수 있다")
+    void getFollowings_success() {
+        followService.follow(targetId);
+
+        List<MemberProfileDto> result = followService.getFollowings(meId);
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getNickname()).isEqualTo("상대방");
+    }
+
+    @Test
+    @DisplayName("팔로워 목록을 조회할 수 있다")
+    void getFollowers_success() {
+        // 상대방이 나를 팔로우한 상황 만들기
+        // (이 경우 상대방을 로그인 상태로 설정 후 follow 호출)
+        RegisterRequest other = new RegisterRequest(
+                "another@resona.com",
+                "pw",
+                CountryCode.KR,
+                CountryCode.KR,
+                Set.of(Language.KOREAN),
+                Set.of(Language.ENGLISH),
+                1,
+                "2000-01-01",
+                "제3자",
+                "http://img.third"
+        );
+        memberService.signUp(other);
+
+        Long thirdId = memberRepository.findByEmail("another@resona.com").orElseThrow().getId();
+
+        // 로그인 교체
+        User third = new User("another@resona.com", "", new ArrayList<>());
+        SecurityContextHolder.getContext().setAuthentication(
+                new UsernamePasswordAuthenticationToken(third, null, third.getAuthorities()));
+
+        followService.follow(meId); // 제3자가 나(meId)를 팔로우
+
+        List<MemberProfileDto> result = followService.getFollowers(meId);
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getNickname()).isEqualTo("제3자");
+    }
+}


### PR DESCRIPTION
## 📌 개요
- Follow 기능 전반을 구현했습니다.  
- 팔로우/언팔로우 기능과 팔로워/팔로잉 목록 조회 기능을 개발하고,  
  실제 로그인 흐름을 반영한 통합 테스트까지 작성했습니다.

---

## 🛠️ 작업 내용

- [x] `FollowService` 구현 (`follow`, `unfollow`, `getFollowers`, `getFollowings`)
- [x] `FollowRepository`에 fetch join 기반 쿼리 작성 및 최적화
- [x] 중복 row 발생 방지를 위한 `DISTINCT` 적용
- [x] `FollowController` 구현 (REST API)
- [x] 인증된 사용자를 통한 통합 테스트 작성

---

## 🧩 FollowService 및 fetch join 최적화

```java
@Query("SELECT DISTINCT f FROM Follow f " +
       "JOIN FETCH f.follower m " +
       "JOIN FETCH m.profile " +
       "WHERE f.following.id = :memberId")
List<Follow> findFollowersByFollowingId(@Param("memberId") Long memberId);
```

- `Member`의 `Profile`까지 fetch join으로 가져오고 중복 제거를 위해 `DISTINCT` 사용  
- `Follow` 조회 시 N+1 없이 `Profile`까지 한 번에 로딩됨

---

## 📡 FollowController 기능

| 메서드 | 설명 |
|--------|------|
| `POST /follow/{memberId}` | 로그인된 사용자가 특정 사용자를 팔로우 |
| `DELETE /follow/{memberId}` | 로그인된 사용자가 특정 사용자를 언팔로우 |
| `GET /follow/{memberId}/followers` | 특정 사용자의 팔로워 목록 조회 |
| `GET /follow/{memberId}/followings` | 특정 사용자의 팔로잉 목록 조회 |

---

## 📌 차후 계획

- 팔로우 알림 기능 확장
- 팔로워/팔로잉 수 조회 API (`/follow/count`) 구현 고려

---

## ✅ 테스트 케이스

- [x] 기능 정상 동작 확인  
- [x] 코드 스타일 및 컨벤션 준수  
- [x] 인증 흐름 반영된 통합 테스트 수행  
- [x] 기존 테스트 통과  

---

## 📌 기타 참고 사항
- `JOIN FETCH`로 인해 중복이 생길 수 있어 `DISTINCT`를 반드시 추가해야 함  

```
🔗 관련 이슈: #182 
```