### PR TITLE
Fix: 회원가입시 멤버가 2개가 생성되는 오류 해결

### DIFF
--- a/src/main/java/synapps/resona/api/mysql/member/entity/account/AccountInfo.java
+++ b/src/main/java/synapps/resona/api/mysql/member/entity/account/AccountInfo.java
@@ -54,6 +54,11 @@ public class AccountInfo extends BaseEntity {
         this.status = accountStatus;
     }
 
+    public void join() {
+        this.status = AccountStatus.ACTIVE;
+        this.roleType = RoleType.USER;
+    }
+
     public void updateRoleType(RoleType roleType) {
         this.roleType = roleType;
     }

--- a/src/main/java/synapps/resona/api/mysql/member/entity/member_details/MemberDetails.java
+++ b/src/main/java/synapps/resona/api/mysql/member/entity/member_details/MemberDetails.java
@@ -92,8 +92,6 @@ public class MemberDetails extends BaseEntity {
         return new MemberDetails(timezone);
     }
 
-
-
     public void modifyMemberDetails(Integer timezone,
                                    String phoneNumber,
                                    MBTI mbti,
@@ -104,5 +102,9 @@ public class MemberDetails extends BaseEntity {
         this.mbti = mbti;
         this.aboutMe = aboutMe;
         this.location = location;
+    }
+
+    public void join(Integer timezone) {
+        this.timezone = timezone;
     }
 }

--- a/src/main/java/synapps/resona/api/mysql/member/entity/profile/Profile.java
+++ b/src/main/java/synapps/resona/api/mysql/member/entity/profile/Profile.java
@@ -185,6 +185,23 @@ public class Profile extends BaseEntity {
         this.comment = comment;
     }
 
+    public void join(String nickname,
+                     CountryCode nationality,
+                     CountryCode countryOfResidence,
+                     Set<Language> nativeLanguages,
+                     Set<Language> interestingLanguages,
+                     String profileImageUrl,
+                     String birth) {
+        this.nickname = nickname;
+        this.nationality = nationality;
+        this.countryOfResidence = countryOfResidence;
+        this.nativeLanguages = nativeLanguages;
+        this.interestingLanguages = interestingLanguages;
+        this.profileImageUrl = profileImageUrl;
+        this.birth = parseToLocalDate(birth);
+        this.age = birthToAge(parseToLocalDate(birth));
+    }
+
     public void changeBackgroundUrl(String url) {
         this.backgroundImageUrl = url;
     }

--- a/src/main/java/synapps/resona/api/mysql/member/service/MemberService.java
+++ b/src/main/java/synapps/resona/api/mysql/member/service/MemberService.java
@@ -25,7 +25,10 @@ import synapps.resona.api.mysql.member.entity.profile.Language;
 import synapps.resona.api.mysql.member.entity.profile.Profile;
 import synapps.resona.api.mysql.member.exception.AccountInfoException;
 import synapps.resona.api.mysql.member.exception.MemberException;
+import synapps.resona.api.mysql.member.repository.AccountInfoRepository;
+import synapps.resona.api.mysql.member.repository.MemberDetailsRepository;
 import synapps.resona.api.mysql.member.repository.MemberRepository;
+import synapps.resona.api.mysql.member.repository.ProfileRepository;
 import synapps.resona.api.mysql.token.AuthToken;
 import synapps.resona.api.mysql.token.AuthTokenProvider;
 import synapps.resona.api.oauth.entity.ProviderType;
@@ -38,6 +41,9 @@ import java.util.Set;
 @RequiredArgsConstructor
 public class MemberService {
     private final MemberRepository memberRepository;
+    private final ProfileRepository profileRepository;
+    private final MemberDetailsRepository memberDetailsRepository;
+    private final AccountInfoRepository accountInfoRepository;
     private final AuthTokenProvider authTokenProvider;
     private final Logger logger = LogManager.getLogger(MemberService.class);
 
@@ -93,65 +99,57 @@ public class MemberService {
     @Transactional
     public MemberRegisterResponseDto signUp(RegisterRequest request) {
         checkMemberStatus(request);
+        Member member = memberRepository.findWithAllRelationsByEmail(request.getEmail()).orElseThrow(MemberException::memberNotFound);
 
-        Profile newProfile = Profile.of(
+        Profile profile = member.getProfile();
+        MemberDetails memberDetails = member.getMemberDetails();
+        AccountInfo accountInfo = member.getAccountInfo();
+
+        profile.join(
+                request.getNickname(),
                 request.getNationality(),
                 request.getCountryOfResidence(),
                 copyToMutableSet(request.getNativeLanguages()),
                 copyToMutableSet(request.getInterestingLanguages()),
-                request.getNickname(),
                 request.getProfileImageUrl(),
-                request.getBirth()
-        );
+                request.getBirth());
+        memberDetails.join(request.getTimezone());
+        accountInfo.join();
 
-        MemberDetails newMemberDetails = MemberDetails.of(
-                request.getTimezone()
-        );
-
-
-        AccountInfo newAccountInfo = AccountInfo.of(
-                RoleType.USER,
-                ProviderType.LOCAL,
-                AccountStatus.ACTIVE
-        );
-
-        Member member = Member.of(
-                newAccountInfo,
-                newMemberDetails,
-                newProfile,
-                request.getEmail(),
-                request.getPassword(),
-                LocalDateTime.now() // lastAccessedAt
-        );
 
         member.encodePassword(request.getPassword());
         memberRepository.save(member);
+        profileRepository.save(profile);
+        memberDetailsRepository.save(memberDetails);
+        accountInfoRepository.save(accountInfo);
 
         return MemberRegisterResponseDto.builder()
                 .memberId(member.getId())
                 .email(member.getEmail())
-                .nationality(newProfile.getNationality())
-                .countryOfResidence(newProfile.getCountryOfResidence())
-                .nativeLanguages(newProfile.getNativeLanguages())
-                .interestingLanguages(newProfile.getInterestingLanguages())
-                .birth(newProfile.getBirth().toString())
-                .nickname(newProfile.getNickname())
-                .profileImageUrl(newProfile.getProfileImageUrl())
-                .timezone(newMemberDetails.getTimezone())
+                .nationality(profile.getNationality())
+                .countryOfResidence(profile.getCountryOfResidence())
+                .nativeLanguages(profile.getNativeLanguages())
+                .interestingLanguages(profile.getInterestingLanguages())
+                .birth(profile.getBirth().toString())
+                .nickname(profile.getNickname())
+                .profileImageUrl(profile.getProfileImageUrl())
+                .timezone(memberDetails.getTimezone())
                 .build();
     }
 
     private void checkMemberStatus(RegisterRequest request) {
-        if (memberRepository.existsByEmail(request.getEmail())) {
-            AccountInfo accountInfo = memberRepository.findAccountInfoByEmail(request.getEmail()).orElseThrow(AccountInfoException::accountInfoNotFound);
-            // 차단당한 계정인 경우
-            if (accountInfo.getStatus().equals(AccountStatus.BANNED)) {
-                throw MemberException.unAuthenticatedRequest();
-            }
-            // 이미 활성화된 계정인 경우
-            if (accountInfo.getStatus().equals(AccountStatus.ACTIVE)) {
-                throw MemberException.duplicateEmail();
-            }
+        boolean isMemberExists = memberRepository.existsByEmail(request.getEmail());
+        if (!isMemberExists) {
+            throw MemberException.memberNotFound();
+        }
+        AccountInfo accountInfo = memberRepository.findAccountInfoByEmail(request.getEmail()).orElseThrow(AccountInfoException::accountInfoNotFound);
+        // 차단당한 계정인 경우
+        if (accountInfo.getStatus().equals(AccountStatus.BANNED)) {
+            throw MemberException.unAuthenticatedRequest();
+        }
+        // 이미 활성화된 계정인 경우
+        if (accountInfo.getStatus().equals(AccountStatus.ACTIVE)) {
+            throw MemberException.duplicateEmail();
         }
     }
 


### PR DESCRIPTION
## 📌 개요
회원가입을 하기 전, 무조건적으로 이메일 인증 혹은 sns로 회원가입시 엔티티가 생성됩니다. 하지만 이걸 간과하고 회원가입시 새로 엔티티를 생성해서 저장해서, 로그인 시 멤버가 2명씩 잡히는 오류가 났었습니다.

## 🛠️ 작업 내용
- [x] 각 엔티티에 join 메서드 구현, 회원가입(member/join) 시 기존 엔티티를 수정하여 반영되게 수정

#### 🙏🏻아래와 같이 PR을 리뷰해주세요.
- PR 내용이 부족하다면 보충 요청해주세요.
- 코드 스타일이 팀의 규칙에 맞게 작성되었는지, 일관성을 유지하고 있는지 확인해주세요.
- 코드에 대한 문서화나 주석이 필요한 부분에 적절하게 작성되어 있는지 확인해주세요.
- 구현된 로직이 효율적이고 올바르게 작성되었는지, 아키텍처를 잘 준수하고 있는지 검토해주세요.
- 네이밍, 포매팅, 주석 등 코드의 일관성이 유지되고 있는지 확인해주세요.