### PR TITLE
[Refactor] 소셜 로그인과 자체 로그인시 로그인 충돌이 나는 문제 해결

### DIFF
--- a/src/main/java/synapps/resona/api/global/exception/ErrorCode.java
+++ b/src/main/java/synapps/resona/api/global/exception/ErrorCode.java
@@ -26,6 +26,9 @@ public enum ErrorCode {
     NOT_EXPIRED(HttpStatus.NOT_ACCEPTABLE, "AUTH007", "Access token not Expired"),
     FORBIDDEN(HttpStatus.FORBIDDEN, "AUTH008", "You do not have permission to access this resource."),
 
+    // oauth
+    PROVIDER_TYPE_MISSMATCH(HttpStatus.CONFLICT, "OAUTH001", "Account info missmatch"),
+
     //email
     INVALID_EMAIL_CODE(HttpStatus.UNAUTHORIZED, "EMAIL001", "Invalid email code"),
     EMAIL_SEND_FAILED(HttpStatus.CONFLICT, "EMAIL002", "Email send failed"),

--- a/src/main/java/synapps/resona/api/mysql/member/controller/MemberController.java
+++ b/src/main/java/synapps/resona/api/mysql/member/controller/MemberController.java
@@ -14,7 +14,6 @@ import org.springframework.web.bind.annotation.*;
 import synapps.resona.api.global.config.server.ServerInfoConfig;
 import synapps.resona.api.global.dto.metadata.MetaDataDto;
 import synapps.resona.api.global.dto.response.ResponseDto;
-import synapps.resona.api.mysql.member.dto.request.auth.DuplicateIdRequest;
 import synapps.resona.api.mysql.member.dto.request.auth.RegisterRequest;
 import synapps.resona.api.mysql.member.dto.request.member.MemberPasswordChangeDto;
 import synapps.resona.api.mysql.member.dto.response.MemberRegisterResponseDto;
@@ -67,15 +66,6 @@ public class MemberController {
                                                  HttpServletResponse response) {
         MetaDataDto metaData = createSuccessMetaData(request.getQueryString());
         ResponseDto responseData = new ResponseDto(metaData, List.of(memberService.getMemberDetailInfo()));
-        return ResponseEntity.ok(responseData);
-    }
-
-    @PostMapping("/duplicate-id")
-    public ResponseEntity<?> checkDuplicateId(HttpServletRequest request,
-                                              HttpServletResponse response,
-                                              @RequestBody DuplicateIdRequest duplicateIdRequest) throws Exception {
-        MetaDataDto metaData = createSuccessMetaData(request.getQueryString());
-        ResponseDto responseData = new ResponseDto(metaData, List.of(memberService.checkDuplicateId(duplicateIdRequest)));
         return ResponseEntity.ok(responseData);
     }
 

--- a/src/main/java/synapps/resona/api/mysql/member/controller/ProfileController.java
+++ b/src/main/java/synapps/resona/api/mysql/member/controller/ProfileController.java
@@ -5,11 +5,11 @@ import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 import synapps.resona.api.global.config.server.ServerInfoConfig;
 import synapps.resona.api.global.dto.metadata.MetaDataDto;
 import synapps.resona.api.global.dto.response.ResponseDto;
+import synapps.resona.api.mysql.member.dto.request.profile.DuplicateTagRequest;
 import synapps.resona.api.mysql.member.dto.request.profile.ProfileRequest;
 import synapps.resona.api.mysql.member.service.ProfileService;
 
@@ -29,23 +29,20 @@ public class ProfileController {
     /**
      * security context에 존재하는 유저의 정보를 가져오기 때문에 권한 체크를 하지 않아도 됨.
      * @param request
-     * @param response
      * @param profileRequest
      * @return
      * @throws Exception
      */
     @PostMapping
     public ResponseEntity<?> registerProfile(HttpServletRequest request,
-                                             HttpServletResponse response,
-                                             @Valid @RequestBody ProfileRequest profileRequest) throws Exception {
+                                             @Valid @RequestBody ProfileRequest profileRequest) {
         MetaDataDto metaData = createSuccessMetaData(request.getQueryString());
         ResponseDto responseData = new ResponseDto(metaData, List.of(profileService.register(profileRequest)));
         return ResponseEntity.ok(responseData);
     }
 
     @GetMapping
-    public ResponseEntity<?> readProfile(HttpServletRequest request,
-                                         HttpServletResponse response) throws Exception {
+    public ResponseEntity<?> readProfile(HttpServletRequest request) {
         MetaDataDto metaData = createSuccessMetaData(request.getQueryString());
         ResponseDto responseData = new ResponseDto(metaData, List.of(profileService.readProfile()));
         return ResponseEntity.ok(responseData);
@@ -62,18 +59,24 @@ public class ProfileController {
 
     @PutMapping
     public ResponseEntity<?> editProfile(HttpServletRequest request,
-                                         HttpServletResponse response,
-                                         @Valid @RequestBody ProfileRequest profileRequest) throws Exception {
+                                         @Valid @RequestBody ProfileRequest profileRequest) {
         MetaDataDto metaData = createSuccessMetaData(request.getQueryString());
         ResponseDto responseData = new ResponseDto(metaData, List.of(profileService.editProfile(profileRequest)));
         return ResponseEntity.ok(responseData);
     }
 
     @DeleteMapping
-    public ResponseEntity<?> deleteProfile(HttpServletRequest request,
-                                           HttpServletResponse response) throws Exception {
+    public ResponseEntity<?> deleteProfile(HttpServletRequest request) {
         MetaDataDto metaData = createSuccessMetaData(request.getQueryString());
         ResponseDto responseData = new ResponseDto(metaData, List.of(profileService.deleteProfile()));
+        return ResponseEntity.ok(responseData);
+    }
+
+    @PostMapping("/duplicate-tag")
+    public ResponseEntity<?> checkDuplicateId(HttpServletRequest request,
+                                              @RequestBody DuplicateTagRequest duplicateTagRequest) {
+        MetaDataDto metaData = createSuccessMetaData(request.getQueryString());
+        ResponseDto responseData = new ResponseDto(metaData, List.of(profileService.checkDuplicateTag(duplicateTagRequest.getTag())));
         return ResponseEntity.ok(responseData);
     }
 

--- a/src/main/java/synapps/resona/api/mysql/member/dto/request/profile/DuplicateTagRequest.java
+++ b/src/main/java/synapps/resona/api/mysql/member/dto/request/profile/DuplicateTagRequest.java
@@ -1,4 +1,4 @@
-package synapps.resona.api.mysql.member.dto.request.auth;
+package synapps.resona.api.mysql.member.dto.request.profile;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -7,6 +7,6 @@ import lombok.RequiredArgsConstructor;
 @Data
 @AllArgsConstructor
 @RequiredArgsConstructor
-public class DuplicateIdRequest {
-    private String id;
+public class DuplicateTagRequest {
+    private String tag;
 }

--- a/src/main/java/synapps/resona/api/mysql/member/repository/ProfileRepository.java
+++ b/src/main/java/synapps/resona/api/mysql/member/repository/ProfileRepository.java
@@ -7,4 +7,5 @@ import synapps.resona.api.mysql.member.entity.profile.Profile;
 
 @Repository
 public interface ProfileRepository extends JpaRepository<Profile, Long> {
+    boolean existsByTag(String tag);
 }

--- a/src/main/java/synapps/resona/api/mysql/member/service/MemberService.java
+++ b/src/main/java/synapps/resona/api/mysql/member/service/MemberService.java
@@ -10,7 +10,6 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.stereotype.Service;
 import synapps.resona.api.global.utils.DateTimeUtil;
-import synapps.resona.api.mysql.member.dto.request.auth.DuplicateIdRequest;
 import synapps.resona.api.mysql.member.dto.request.auth.RegisterRequest;
 import synapps.resona.api.mysql.member.dto.request.member.MemberPasswordChangeDto;
 import synapps.resona.api.mysql.member.dto.response.MemberInfoDto;
@@ -147,10 +146,6 @@ public class MemberService {
         if (accountInfo.getStatus().equals(AccountStatus.ACTIVE)) {
             throw MemberException.duplicateEmail();
         }
-    }
-
-    public boolean checkDuplicateId(DuplicateIdRequest request) throws Exception {
-        return memberRepository.existsById(Long.parseLong(request.getId()));
     }
 
     @Transactional

--- a/src/main/java/synapps/resona/api/mysql/member/service/ProfileService.java
+++ b/src/main/java/synapps/resona/api/mysql/member/service/ProfileService.java
@@ -78,6 +78,10 @@ public class ProfileService {
         return profile;
     }
 
+    public boolean checkDuplicateTag(String tag) {
+        return profileRepository.existsByTag(tag);
+    }
+
     private void validateData(ProfileRequest request) {
         validateTimeStamp(request.getBirth());
     }

--- a/src/main/java/synapps/resona/api/oauth/exception/OAuthException.java
+++ b/src/main/java/synapps/resona/api/oauth/exception/OAuthException.java
@@ -1,0 +1,27 @@
+package synapps.resona.api.oauth.exception;
+
+import org.springframework.http.HttpStatus;
+import synapps.resona.api.global.exception.BaseException;
+import synapps.resona.api.global.exception.ErrorCode;
+import synapps.resona.api.mysql.member.entity.account.AccountInfo;
+import synapps.resona.api.oauth.entity.ProviderType;
+
+public class OAuthException extends BaseException {
+    protected OAuthException(String message, HttpStatus status, String errorCode) {
+        super(message, status, errorCode);
+    }
+
+    private static OAuthException of(ErrorCode errorCode) {
+        return new OAuthException(errorCode.getMessage(), errorCode.getStatus(), errorCode.getCode());
+    }
+
+    private static OAuthException of(ErrorCode errorCode, String customMessage) {
+        return new OAuthException(customMessage, errorCode.getStatus(), errorCode.getCode());
+    }
+
+    public static OAuthException OAuthProviderMissMatch(ProviderType providerType) {
+        String message = "Looks like you're signed up with wrong account. Please use your " + providerType + " account to login.";
+
+        return of(ErrorCode.PROVIDER_TYPE_MISSMATCH, message);
+    }
+}

--- a/src/main/java/synapps/resona/api/oauth/exception/OAuthProviderMissMatchException.java
+++ b/src/main/java/synapps/resona/api/oauth/exception/OAuthProviderMissMatchException.java
@@ -1,8 +1,18 @@
 package synapps.resona.api.oauth.exception;
 
-public class OAuthProviderMissMatchException extends RuntimeException {
+import org.springframework.http.HttpStatus;
+import synapps.resona.api.global.exception.BaseException;
+import synapps.resona.api.global.exception.ErrorCode;
 
-    public OAuthProviderMissMatchException(String message) {
-        super(message);
+public class OAuthProviderMissMatchException extends BaseException {
+
+    protected OAuthProviderMissMatchException(String message, HttpStatus status, String errorCode) {
+        super(message, status, errorCode);
     }
+
+    private static OAuthProviderMissMatchException of(ErrorCode errorCode) {
+        return new OAuthProviderMissMatchException(errorCode.getMessage(), errorCode.getStatus(), errorCode.getCode());
+    }
+
+
 }

--- a/src/main/java/synapps/resona/api/oauth/service/CustomOAuth2UserService.java
+++ b/src/main/java/synapps/resona/api/oauth/service/CustomOAuth2UserService.java
@@ -17,6 +17,7 @@ import synapps.resona.api.mysql.member.repository.MemberRepository;
 import synapps.resona.api.mysql.token.AuthTokenProvider;
 import synapps.resona.api.oauth.entity.ProviderType;
 import synapps.resona.api.oauth.entity.UserPrincipal;
+import synapps.resona.api.oauth.exception.OAuthException;
 import synapps.resona.api.oauth.exception.OAuthProviderMissMatchException;
 import synapps.resona.api.oauth.info.OAuth2UserInfo;
 import synapps.resona.api.oauth.info.OAuth2UserInfoFactory;
@@ -62,12 +63,13 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
         AccountInfo accountInfo = savedMember.getAccountInfo();
 
+        // TODO: Hard coded with providertype google cause we use only google login in oauth. Need to refactor.
+        if (accountInfo.getProviderType() != ProviderType.GOOGLE) {
+            throw OAuthException.OAuthProviderMissMatch(accountInfo.getProviderType());
+        }
 
         if (providerType != accountInfo.getProviderType()) {
-            throw new OAuthProviderMissMatchException(
-                    "Looks like you're signed up with " + providerType +
-                            " account. Please use your " + accountInfo.getProviderType() + " account to login."
-            );
+            throw OAuthException.OAuthProviderMissMatch(accountInfo.getProviderType());
         }
 
         return UserPrincipal.create(savedMember, accountInfo, user.getAttributes());


### PR DESCRIPTION
## 📌 개요
로그인 시 기존 계정 로그인이 있었다면, 다른 이상한 에러가 났었습니다. 그래서 로그인시, 기존 계정의 가입 정보를 확인하여 불일치시 에러를 반환하게 변경하였습니다.

## 🛠️ 작업 내용
- [x] 각 로그인 로직에 가입정보 확인 로직 추가
- [x] 아이디 중복에서 태그 중복으로 API 변경(비즈니스 로직 변경)

## 📌 테스트 케이스
- [x] 기능 정상 동작 확인
- [x] 코드 스타일 및 컨벤션 준수 확인
- [x] 기존 테스트 통과 여부 확인


#### 🙏🏻아래와 같이 PR을 리뷰해주세요.
- PR 내용이 부족하다면 보충 요청해주세요.
- 코드 스타일이 팀의 규칙에 맞게 작성되었는지, 일관성을 유지하고 있는지 확인해주세요.
- 코드에 대한 문서화나 주석이 필요한 부분에 적절하게 작성되어 있는지 확인해주세요.
- 구현된 로직이 효율적이고 올바르게 작성되었는지, 아키텍처를 잘 준수하고 있는지 검토해주세요.
- 네이밍, 포매팅, 주석 등 코드의 일관성이 유지되고 있는지 확인해주세요.