### PR TITLE
[Refactor] 회원가입 시 Profile Tag 등록 및 AccessToken 발급 로직 추가, AuthService 리팩토링

### DIFF
--- a/src/main/java/synapps/resona/api/global/exception/ErrorCode.java
+++ b/src/main/java/synapps/resona/api/global/exception/ErrorCode.java
@@ -45,6 +45,7 @@ public enum ErrorCode {
     // profile
     PROFILE_INPUT_INVALID(HttpStatus.CONFLICT, "PROFILE001", "Invalid profile"),
     PROFILE_NOT_FOUND(HttpStatus.NOT_FOUND, "PROFILE002", "Profile not fouond"),
+    DUPLICATE_TAG(HttpStatus.CONFLICT, "PROFILE003", "Tag duplicate"),
 
     // member details
     MEMBER_DETAILS_NOT_FOUND(HttpStatus.NOT_FOUND, "MDETAILS001", "Member Details not found"),

--- a/src/main/java/synapps/resona/api/mysql/member/controller/AuthController.java
+++ b/src/main/java/synapps/resona/api/mysql/member/controller/AuthController.java
@@ -15,6 +15,7 @@ import synapps.resona.api.global.exception.ErrorCode;
 import synapps.resona.api.mysql.member.dto.request.auth.AppleLoginRequest;
 import synapps.resona.api.mysql.member.dto.request.auth.LoginRequest;
 import synapps.resona.api.mysql.member.dto.request.auth.RefreshRequest;
+import synapps.resona.api.mysql.member.dto.response.TokenResponse;
 import synapps.resona.api.mysql.member.service.AuthService;
 
 import java.util.List;
@@ -36,21 +37,29 @@ public class AuthController {
             HttpServletRequest request,
             HttpServletResponse response,
             @RequestBody LoginRequest loginRequest) {
-        return authService.login(request, response, loginRequest);
+        TokenResponse tokenResponse = authService.login(loginRequest);
+        MetaDataDto metaData = createSuccessMetaData(request.getQueryString());
+        return ResponseEntity.ok(new ResponseDto(metaData, List.of(tokenResponse)));
     }
 
     @PostMapping("/apple")
     public ResponseEntity<?> appleLogin(
             HttpServletRequest request,
             HttpServletResponse response,
-            @RequestBody AppleLoginRequest appleRequest
-    ) throws Exception {
-        return authService.appleLogin(request, response, appleRequest);
+            @RequestBody AppleLoginRequest appleRequest) throws Exception {
+        TokenResponse tokenResponse = authService.appleLogin(request, response, appleRequest);
+        MetaDataDto metaData = createSuccessMetaData(request.getQueryString());
+        return ResponseEntity.ok(new ResponseDto(metaData, List.of(tokenResponse)));
     }
 
     @GetMapping("/refresh-token")
-    public ResponseEntity<?> refreshToken(HttpServletRequest request, HttpServletResponse response, @RequestBody RefreshRequest refreshRequest) {
-        return authService.refresh(request, response, refreshRequest);
+    public ResponseEntity<?> refreshToken(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            @RequestBody RefreshRequest refreshRequest) {
+        TokenResponse tokenResponse = authService.refresh(request, refreshRequest);
+        MetaDataDto metaData = createSuccessMetaData(request.getQueryString());
+        return ResponseEntity.ok(new ResponseDto(metaData, List.of(tokenResponse)));
     }
 
     @GetMapping("/member")

--- a/src/main/java/synapps/resona/api/mysql/member/controller/MemberController.java
+++ b/src/main/java/synapps/resona/api/mysql/member/controller/MemberController.java
@@ -6,7 +6,6 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -14,9 +13,12 @@ import org.springframework.web.bind.annotation.*;
 import synapps.resona.api.global.config.server.ServerInfoConfig;
 import synapps.resona.api.global.dto.metadata.MetaDataDto;
 import synapps.resona.api.global.dto.response.ResponseDto;
+import synapps.resona.api.mysql.member.dto.request.auth.LoginRequest;
 import synapps.resona.api.mysql.member.dto.request.auth.RegisterRequest;
 import synapps.resona.api.mysql.member.dto.request.member.MemberPasswordChangeDto;
 import synapps.resona.api.mysql.member.dto.response.MemberRegisterResponseDto;
+import synapps.resona.api.mysql.member.dto.response.TokenResponse;
+import synapps.resona.api.mysql.member.service.AuthService;
 import synapps.resona.api.mysql.member.service.MemberService;
 
 import java.util.List;
@@ -26,13 +28,12 @@ import java.util.List;
 @RequiredArgsConstructor
 public class MemberController {
     private final MemberService memberService;
+    private final AuthService authService;
     private final ServerInfoConfig serverInfo;
 
     private MetaDataDto createSuccessMetaData(String queryString) {
         return MetaDataDto.createSuccessMetaData(queryString, serverInfo.getApiVersion(), serverInfo.getServerName());
     }
-
-
 
     // TODO: 커스텀 어노테이션으로 클래스 설정만 해줄 수 있게 하는 코드가 필요해보임
     @Operation(summary = "회원 등록", description = "회원 등록 후 응답 DTO 반환")
@@ -46,24 +47,24 @@ public class MemberController {
     )
     @PostMapping("/join")
     public ResponseEntity<?> join(HttpServletRequest request,
-                                  HttpServletResponse response,
                                   @Valid @RequestBody RegisterRequest registerRequest) {
         MetaDataDto metaData = createSuccessMetaData(request.getQueryString());
-        ResponseDto responseData = new ResponseDto(metaData, List.of(memberService.signUp(registerRequest)));
+        MemberRegisterResponseDto memberRegisterResponseDto = memberService.signUp(registerRequest);
+        LoginRequest loginRequest = new LoginRequest(registerRequest.getEmail(), registerRequest.getPassword());
+        TokenResponse tokenResponse = authService.login(loginRequest);
+        ResponseDto responseData = new ResponseDto(metaData, List.of(memberRegisterResponseDto, tokenResponse));
         return ResponseEntity.ok(responseData);
     }
 
     @GetMapping("/info")
-    public ResponseEntity<?> getUser(HttpServletRequest request,
-                                     HttpServletResponse response) {
+    public ResponseEntity<?> getUser(HttpServletRequest request) {
         MetaDataDto metaData = createSuccessMetaData(request.getQueryString());
         ResponseDto responseData = new ResponseDto(metaData, List.of(memberService.getMember()));
         return ResponseEntity.ok(responseData);
     }
 
     @GetMapping("/detail")
-    public ResponseEntity<?> getMemberDetailInfo(HttpServletRequest request,
-                                                 HttpServletResponse response) {
+    public ResponseEntity<?> getMemberDetailInfo(HttpServletRequest request) {
         MetaDataDto metaData = createSuccessMetaData(request.getQueryString());
         ResponseDto responseData = new ResponseDto(metaData, List.of(memberService.getMemberDetailInfo()));
         return ResponseEntity.ok(responseData);
@@ -71,16 +72,14 @@ public class MemberController {
 
     @PostMapping("/password")
     public ResponseEntity<?> changePassword(HttpServletRequest request,
-                                            HttpServletResponse response,
-                                            @RequestBody MemberPasswordChangeDto requestBody) throws Exception {
+                                            @RequestBody MemberPasswordChangeDto requestBody) {
         MetaDataDto metaData = createSuccessMetaData(request.getQueryString());
         ResponseDto responseDto = new ResponseDto(metaData, List.of(memberService.changePassword(request, requestBody)));
         return ResponseEntity.ok(responseDto);
     }
 
     @DeleteMapping()
-    public ResponseEntity<?> deleteUser(HttpServletRequest request,
-                                        HttpServletResponse response) {
+    public ResponseEntity<?> deleteUser(HttpServletRequest request) {
         MetaDataDto metaData = createSuccessMetaData(request.getQueryString());
         ResponseDto responseData = new ResponseDto(metaData, List.of(memberService.deleteUser()));
         return ResponseEntity.ok(responseData);

--- a/src/main/java/synapps/resona/api/mysql/member/dto/request/auth/RegisterRequest.java
+++ b/src/main/java/synapps/resona/api/mysql/member/dto/request/auth/RegisterRequest.java
@@ -22,6 +22,10 @@ public class RegisterRequest {
     private String email;
 
     @NotBlank
+    @Size(max = 20)
+    private String tag;
+
+    @NotBlank
     @Size(max = 120)
     @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[@$!%*#?&])[A-Za-z\\d@$!%*#?&]{8,30}$",
             message = "비밀번호는 8~30 자리이면서 1개 이상의 알파벳, 숫자, 특수문자를 포함해야합니다.")

--- a/src/main/java/synapps/resona/api/mysql/member/dto/response/MemberRegisterResponseDto.java
+++ b/src/main/java/synapps/resona/api/mysql/member/dto/response/MemberRegisterResponseDto.java
@@ -25,6 +25,9 @@ public class MemberRegisterResponseDto {
     @Schema(description = "회원 닉네임", example = "newuser")
     private String nickname;
 
+    @Schema(description = "회원 태그", example = "spculatingwook")
+    private String tag;
+
     @Schema(description = "회원 국적 코드", example = "KR")
     private CountryCode nationality;
 

--- a/src/main/java/synapps/resona/api/mysql/member/entity/profile/Profile.java
+++ b/src/main/java/synapps/resona/api/mysql/member/entity/profile/Profile.java
@@ -1,7 +1,6 @@
 package synapps.resona.api.mysql.member.entity.profile;
 
 import jakarta.persistence.*;
-import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.AccessLevel;
@@ -9,13 +8,9 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import synapps.resona.api.global.entity.BaseEntity;
 import synapps.resona.api.global.utils.DateTimeUtil;
-import synapps.resona.api.mysql.member.entity.member.Member;
-import synapps.resona.api.mysql.member.util.HashGenerator;
-import synapps.resona.api.mysql.member.util.MD5Generator;
 
 import java.time.LocalDateTime;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 
 @Entity
@@ -84,7 +79,9 @@ public class Profile extends BaseEntity {
     private Gender gender;
 
 
+    // 생성자 - 일반 프로필 생성
     private Profile(String nickname,
+                    String tag,
                     CountryCode nationality,
                     CountryCode countryOfResidence,
                     Set<Language> nativeLanguages,
@@ -94,8 +91,9 @@ public class Profile extends BaseEntity {
                     String birth,
                     Gender gender,
                     String comment) {
-        this.tag = generateTag(String.valueOf(id));
+
         this.nickname = nickname;
+        this.tag = tag;
         this.nationality = nationality;
         this.countryOfResidence = countryOfResidence;
         this.nativeLanguages = nativeLanguages;
@@ -103,34 +101,38 @@ public class Profile extends BaseEntity {
         this.profileImageUrl = profileImageUrl;
         this.backgroundImageUrl = backgroundImageUrl;
         this.birth = parseToLocalDate(birth);
-        this.age = birthToAge(parseToLocalDate(birth));
+        this.age = birthToAge(this.birth);
         this.gender = gender;
         this.comment = comment;
     }
 
+    // 회원가입용 프로필 생성
     private Profile(CountryCode nationality,
                     CountryCode countryOfResidence,
                     Set<Language> nativeLanguages,
                     Set<Language> interestingLanguages,
                     String nickname,
+                    String tag,
                     String profileImageUrl,
                     String birth) {
-        this.tag = generateTag(String.valueOf(id));
-        this.nickname = nickname;
+
         this.nationality = nationality;
         this.countryOfResidence = countryOfResidence;
         this.nativeLanguages = nativeLanguages;
         this.interestingLanguages = interestingLanguages;
+        this.nickname = nickname;
+        this.tag = tag;
         this.profileImageUrl = profileImageUrl;
         this.birth = parseToLocalDate(birth);
-        this.age = birthToAge(parseToLocalDate(birth));
+        this.age = birthToAge(this.birth);
         this.backgroundImageUrl = "";
         this.gender = Gender.NOT_DECIDED;
         this.comment = "";
     }
 
-    public static Profile of(
-                             String nickname,
+    // 일반 프로필 생성
+    public static Profile of(String nickname,
+                             String tag,
                              CountryCode nationality,
                              CountryCode countryOfResidence,
                              Set<Language> nativeLanguages,
@@ -140,27 +142,36 @@ public class Profile extends BaseEntity {
                              String birth,
                              Gender gender,
                              String comment) {
-        return new Profile(nickname, nationality, countryOfResidence,
+
+        return new Profile(nickname, tag, nationality, countryOfResidence,
                 nativeLanguages, interestingLanguages, profileImageUrl,
                 backgroundImageUrl, birth, gender, comment);
     }
 
-    // 회원가입용 profile
-
+    // 회원가입용
     public static Profile of(CountryCode nationality,
                              CountryCode countryOfResidence,
                              Set<Language> nativeLanguages,
                              Set<Language> interestingLanguages,
                              String nickname,
+                             String tag,
                              String profileImageUrl,
                              String birth) {
-        return new Profile(nationality, countryOfResidence, nativeLanguages, interestingLanguages, nickname, profileImageUrl, birth);
+
+        return new Profile(nationality, countryOfResidence,
+                nativeLanguages, interestingLanguages,
+                nickname, tag, profileImageUrl, birth);
     }
 
+    // 빈 프로필
     public static Profile empty() {
-        return new Profile("", CountryCode.NOT_DEFINED, CountryCode.NOT_DEFINED,
-                new HashSet<>(), new HashSet<>(), "", "", "2000-01-01", Gender.NOT_DECIDED, "");
+        return new Profile("", "none",
+                CountryCode.NOT_DEFINED, CountryCode.NOT_DEFINED,
+                new HashSet<>(), new HashSet<>(),
+                "", "", "2000-01-01",
+                Gender.NOT_DECIDED, "");
     }
+
 
     public void modifyProfile(String nickname,
                               CountryCode nationality,
@@ -214,9 +225,8 @@ public class Profile extends BaseEntity {
         this.gender = Gender.of(gender);
     }
 
-    private String generateTag(String input) {
-        HashGenerator md5generator = new MD5Generator();
-        return md5generator.generateHash(input);
+    public void registerTag(String tag) {
+        this.tag = tag;
     }
 
     private Integer birthToAge(LocalDateTime birth) {

--- a/src/main/java/synapps/resona/api/mysql/member/exception/ProfileException.java
+++ b/src/main/java/synapps/resona/api/mysql/member/exception/ProfileException.java
@@ -20,4 +20,8 @@ public class ProfileException extends BaseException {
     public static ProfileException profileNotFound() {
         return of(ErrorCode.PROFILE_NOT_FOUND);
     }
+
+    public static ProfileException duplicateTag() {
+        return of(ErrorCode.DUPLICATE_TAG);
+    }
 }

--- a/src/main/java/synapps/resona/api/mysql/member/service/MemberService.java
+++ b/src/main/java/synapps/resona/api/mysql/member/service/MemberService.java
@@ -12,8 +12,8 @@ import org.springframework.stereotype.Service;
 import synapps.resona.api.global.utils.DateTimeUtil;
 import synapps.resona.api.mysql.member.dto.request.auth.RegisterRequest;
 import synapps.resona.api.mysql.member.dto.request.member.MemberPasswordChangeDto;
-import synapps.resona.api.mysql.member.dto.response.MemberInfoDto;
 import synapps.resona.api.mysql.member.dto.response.MemberDto;
+import synapps.resona.api.mysql.member.dto.response.MemberInfoDto;
 import synapps.resona.api.mysql.member.dto.response.MemberRegisterResponseDto;
 import synapps.resona.api.mysql.member.entity.account.AccountInfo;
 import synapps.resona.api.mysql.member.entity.account.AccountStatus;
@@ -23,6 +23,7 @@ import synapps.resona.api.mysql.member.entity.profile.Language;
 import synapps.resona.api.mysql.member.entity.profile.Profile;
 import synapps.resona.api.mysql.member.exception.AccountInfoException;
 import synapps.resona.api.mysql.member.exception.MemberException;
+import synapps.resona.api.mysql.member.exception.ProfileException;
 import synapps.resona.api.mysql.member.repository.AccountInfoRepository;
 import synapps.resona.api.mysql.member.repository.MemberDetailsRepository;
 import synapps.resona.api.mysql.member.repository.MemberRepository;
@@ -98,6 +99,11 @@ public class MemberService {
         Member member = memberRepository.findWithAllRelationsByEmail(request.getEmail()).orElseThrow(MemberException::memberNotFound);
 
         Profile profile = member.getProfile();
+        if (profileRepository.existsByTag(request.getTag())) {
+            throw ProfileException.duplicateTag();
+        }
+        profile.registerTag(request.getTag());
+
         MemberDetails memberDetails = member.getMemberDetails();
         AccountInfo accountInfo = member.getAccountInfo();
 
@@ -121,6 +127,7 @@ public class MemberService {
         return MemberRegisterResponseDto.builder()
                 .memberId(member.getId())
                 .email(member.getEmail())
+                .tag(profile.getTag())
                 .nationality(profile.getNationality())
                 .countryOfResidence(profile.getCountryOfResidence())
                 .nativeLanguages(profile.getNativeLanguages())


### PR DESCRIPTION
## 📌 개요

- 회원가입 이후 사용자 편의성을 높이기 위해 **즉시 로그인 처리(AccessToken 발급)** 기능을 추가하였습니다.
- 요구사항에 맞게 **Profile의 Tag 필드 처리 방식**을 수정하여 새로운 태그 엔티티 구조에 맞춰 저장되도록 반영했습니다.
- AccessToken 발급은 기존 `AuthService.login()` 로직을 재활용하여 **회원가입 완료 후 곧바로 로그인 처리**가 가능하도록 하였습니다.
- 또한 `AuthService` 내부에서 Controller의 책임까지 처리하던 부분을 제거하고, **응답 포맷 처리 책임을 Controller로 위임**하여 계층별 역할을 명확히 분리했습니다.

---

## 🛠️ 작업 내용

-  `AuthService.login()`, `appleLogin()`, `refresh()` 메서드 → `TokenResponse`만 반환하도록 수정
-  `AuthController`에서 `MetaDataDto`, `ResponseDto` 생성하도록 책임 분리
-  `MemberController` 회원가입 로직에 AccessToken 발급 로직 추가 (`authService.login()` 재활용)
-  `Profile` 생성 시 태그 처리 구조 변경 (Set 형태 → 엔티티 기반 구조로 리팩토링)
-  전체 인증 및 회원가입 흐름 수동 검증 완료

---

### 🔄 AuthService 책임 분리

|변경 전|변경 후|
|---|---|
|Service에서 직접 ResponseEntity 반환|TokenResponse만 반환|
|응답 포맷 구성까지 Service 책임|응답 포맷은 Controller가 담당|

> → Service는 비즈니스 로직 수행에만 집중할 수 있도록 역할 정리

---

### 🆕 회원가입 + AccessToken 발급

- `MemberController.register()` 내부에서 회원가입 이후 `authService.login()` 호출
- 토큰까지 함께 반환하여 사용자 입장에서 **가입 → 자동 로그인** 경험 제공

|기존 흐름|개선된 흐름|
|---|---|
|회원가입 후 응답만 반환|회원가입 + 토큰 발급 응답|

---

## 📌 테스트 케이스

-  기능 정상 동작 확인
    - `/auth` 로그인
    - `/auth/apple` 애플 로그인
    - `/auth/refresh-token` 토큰 재발급
    - `/member/register` → 자동 토큰 발급 포함
-  코드 스타일 및 컨벤션 준수 확인
-  기존 테스트 통과 및 주요 흐름 수동 검증 완료
-  새로운 의존성 없음

---

### 📌 기타 참고 사항

- `AuthService` 리팩토링을 통해 Controller ↔ Service 간 역할이 명확해졌으며, 테스트 작성 및 유지보수 편의성이 크게 향상될 것으로 기대됩니다.