### PR TITLE
[Fix] Member 상세 조회 시 LazyInitializationException 발생 문제 해결

### DIFF
--- a/src/main/java/synapps/resona/api/mysql/member/repository/MemberRepository.java
+++ b/src/main/java/synapps/resona/api/mysql/member/repository/MemberRepository.java
@@ -17,10 +17,12 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
   Optional<Member> findByEmail(String email);
 
-  @Query("SELECT m FROM Member m " +
+  @Query("SELECT DISTINCT m FROM Member m " +
       "JOIN FETCH m.accountInfo " +
       "JOIN FETCH m.memberDetails " +
-      "JOIN FETCH m.profile " +
+      "JOIN FETCH m.profile p " +
+      "LEFT JOIN FETCH p.nativeLanguages " +
+      "LEFT JOIN FETCH p.interestingLanguages " +
       "WHERE m.email = :email")
   Optional<Member> findWithAllRelationsByEmail(@Param("email") String email);
 


### PR DESCRIPTION
## 📌 개요

- 회원 상세 조회 시 `Profile.nativeLanguages`, `interestingLanguages` 필드가 LAZY 로딩되어 JSON 직렬화 과정에서 `LazyInitializationException`이 발생하는 문제가 있었습니다.  
- 이를 해결하기 위해 JPA fetch join 범위를 확장하여 해당 컬렉션들을 명시적으로 초기화하였습니다.

---

## 🛠️ 작업 내용

- `MemberRepository.findWithAllRelationsByEmail()` 쿼리를 수정하여 `profile.nativeLanguages`, `profile.interestingLanguages`를 `LEFT JOIN FETCH`로 초기화
- LAZY 로딩된 컬렉션을 직렬화 전에 미리 로딩하도록 하여 `HibernateException` 방지
- fetch join 시 row 중복을 방지하기 위해 `DISTINCT` 키워드 추가

수정된 JPQL 쿼리는 다음과 같습니다.

```java
@Query("SELECT DISTINCT m FROM Member m " +
       "JOIN FETCH m.accountInfo " +
       "JOIN FETCH m.memberDetails " +
       "JOIN FETCH m.profile p " +
       "LEFT JOIN FETCH p.nativeLanguages " +
       "LEFT JOIN FETCH p.interestingLanguages " +
       "WHERE m.email = :email")
Optional<Member> findWithAllRelationsByEmail(@Param("email") String email);
```

---
## 📌 테스트 케이스

-  회원 상세 API 호출 시 JSON 직렬화 정상 동작 확인
-  `nativeLanguages`, `interestingLanguages` 필드가 포함된 상태로 응답 확인
-  Hibernate LazyInitializationException 발생 여부 확인
-  중복 row 없이 `Member` 단일 엔티티 정상 반환 (`DISTINCT`)