### PR TITLE
[Refactor] 전역 엔티티에 @SQLRestriction 적용 및 테스트 코드 수정

### DIFF
--- a/src/main/java/synapps/resona/api/mysql/member/entity/account/AccountInfo.java
+++ b/src/main/java/synapps/resona/api/mysql/member/entity/account/AccountInfo.java
@@ -11,12 +11,14 @@ import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLRestriction;
 import synapps.resona.api.global.entity.BaseEntity;
 import synapps.resona.api.oauth.entity.ProviderType;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLRestriction("is_deleted = false")
 public class AccountInfo extends BaseEntity {
 
   @Id

--- a/src/main/java/synapps/resona/api/mysql/member/entity/hobby/Hobby.java
+++ b/src/main/java/synapps/resona/api/mysql/member/entity/hobby/Hobby.java
@@ -13,12 +13,14 @@ import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLRestriction;
 import synapps.resona.api.global.entity.BaseEntity;
 import synapps.resona.api.mysql.member.entity.member_details.MemberDetails;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLRestriction("is_deleted = false")
 public class Hobby extends BaseEntity {
 
   @Id

--- a/src/main/java/synapps/resona/api/mysql/member/entity/member/Follow.java
+++ b/src/main/java/synapps/resona/api/mysql/member/entity/member/Follow.java
@@ -11,11 +11,13 @@ import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLRestriction;
 import synapps.resona.api.global.entity.BaseEntity;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLRestriction("is_deleted = false")
 public class Follow extends BaseEntity {
 
   @Id

--- a/src/main/java/synapps/resona/api/mysql/member/entity/member/Member.java
+++ b/src/main/java/synapps/resona/api/mysql/member/entity/member/Member.java
@@ -22,6 +22,7 @@ import java.util.List;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLRestriction;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import synapps.resona.api.global.entity.BaseEntity;
 import synapps.resona.api.mysql.member.entity.account.AccountInfo;
@@ -38,6 +39,7 @@ import synapps.resona.api.mysql.socialMedia.entity.complaint.FeedComplaint;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLRestriction("is_deleted = false")
 public class Member extends BaseEntity {
 
   @Id

--- a/src/main/java/synapps/resona/api/mysql/member/entity/member_details/MemberDetails.java
+++ b/src/main/java/synapps/resona/api/mysql/member/entity/member_details/MemberDetails.java
@@ -16,12 +16,14 @@ import java.util.List;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLRestriction;
 import synapps.resona.api.global.entity.BaseEntity;
 import synapps.resona.api.mysql.member.entity.hobby.Hobby;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLRestriction("is_deleted = false")
 public class MemberDetails extends BaseEntity {
 
 

--- a/src/main/java/synapps/resona/api/mysql/member/entity/notification/MemberNotification.java
+++ b/src/main/java/synapps/resona/api/mysql/member/entity/notification/MemberNotification.java
@@ -13,12 +13,14 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLRestriction;
 import synapps.resona.api.global.entity.BaseEntity;
 import synapps.resona.api.mysql.member.entity.member.Member;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLRestriction("is_deleted = false")
 public class MemberNotification extends BaseEntity {
 
   @Id

--- a/src/main/java/synapps/resona/api/mysql/member/entity/notification/MemberNotificationSetting.java
+++ b/src/main/java/synapps/resona/api/mysql/member/entity/notification/MemberNotificationSetting.java
@@ -11,11 +11,13 @@ import jakarta.persistence.OneToOne;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLRestriction;
 import synapps.resona.api.mysql.member.entity.member.Member;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLRestriction("is_deleted = false")
 public class MemberNotificationSetting {
 
   @Id

--- a/src/main/java/synapps/resona/api/mysql/member/entity/notification/MemberPushToken.java
+++ b/src/main/java/synapps/resona/api/mysql/member/entity/notification/MemberPushToken.java
@@ -9,12 +9,14 @@ import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLRestriction;
 import synapps.resona.api.global.entity.BaseEntity;
 import synapps.resona.api.mysql.member.entity.member.Member;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLRestriction("is_deleted = false")
 public class MemberPushToken extends BaseEntity {
 
   @Id

--- a/src/main/java/synapps/resona/api/mysql/member/entity/profile/Profile.java
+++ b/src/main/java/synapps/resona/api/mysql/member/entity/profile/Profile.java
@@ -18,12 +18,14 @@ import java.util.Set;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLRestriction;
 import synapps.resona.api.global.entity.BaseEntity;
 import synapps.resona.api.global.utils.DateTimeUtil;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLRestriction("is_deleted = false")
 public class Profile extends BaseEntity {
 
   @Id

--- a/src/main/java/synapps/resona/api/mysql/socialMedia/entity/comment/Comment.java
+++ b/src/main/java/synapps/resona/api/mysql/socialMedia/entity/comment/Comment.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLRestriction;
 import synapps.resona.api.global.entity.BaseEntity;
 import synapps.resona.api.mysql.member.entity.member.Member;
 import synapps.resona.api.mysql.socialMedia.entity.mention.Mention;
@@ -15,6 +16,7 @@ import java.util.List;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLRestriction("is_deleted = false")
 public class Comment extends BaseEntity {
 
   @Id

--- a/src/main/java/synapps/resona/api/mysql/socialMedia/entity/comment/CommentLikes.java
+++ b/src/main/java/synapps/resona/api/mysql/socialMedia/entity/comment/CommentLikes.java
@@ -4,12 +4,14 @@ import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLRestriction;
 import synapps.resona.api.global.entity.BaseEntity;
 import synapps.resona.api.mysql.member.entity.member.Member;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLRestriction("is_deleted = false")
 public class CommentLikes extends BaseEntity {
 
   @Id

--- a/src/main/java/synapps/resona/api/mysql/socialMedia/entity/comment/Reply.java
+++ b/src/main/java/synapps/resona/api/mysql/socialMedia/entity/comment/Reply.java
@@ -11,12 +11,14 @@ import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLRestriction;
 import synapps.resona.api.global.entity.BaseEntity;
 import synapps.resona.api.mysql.member.entity.member.Member;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLRestriction("is_deleted = false")
 public class Reply extends BaseEntity {
 
   @Id

--- a/src/main/java/synapps/resona/api/mysql/socialMedia/entity/complaint/FeedComplaint.java
+++ b/src/main/java/synapps/resona/api/mysql/socialMedia/entity/complaint/FeedComplaint.java
@@ -14,6 +14,7 @@ import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLRestriction;
 import synapps.resona.api.global.entity.BaseEntity;
 import synapps.resona.api.mysql.member.entity.member.Member;
 import synapps.resona.api.mysql.socialMedia.entity.feed.Feed;
@@ -21,6 +22,7 @@ import synapps.resona.api.mysql.socialMedia.entity.feed.Feed;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLRestriction("is_deleted = false")
 public class FeedComplaint extends BaseEntity {
 
   @Id

--- a/src/main/java/synapps/resona/api/mysql/socialMedia/entity/feed/Feed.java
+++ b/src/main/java/synapps/resona/api/mysql/socialMedia/entity/feed/Feed.java
@@ -16,6 +16,7 @@ import java.util.List;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLRestriction;
 import synapps.resona.api.global.entity.BaseEntity;
 import synapps.resona.api.mysql.member.entity.member.Member;
 import synapps.resona.api.mysql.socialMedia.entity.comment.Comment;
@@ -25,8 +26,8 @@ import synapps.resona.api.mysql.socialMedia.entity.media.FeedMedia;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLRestriction("is_deleted = false")
 public class Feed extends BaseEntity {
-
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/synapps/resona/api/mysql/socialMedia/entity/feed/Likes.java
+++ b/src/main/java/synapps/resona/api/mysql/socialMedia/entity/feed/Likes.java
@@ -11,12 +11,14 @@ import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLRestriction;
 import synapps.resona.api.global.entity.BaseEntity;
 import synapps.resona.api.mysql.member.entity.member.Member;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLRestriction("is_deleted = false")
 public class Likes extends BaseEntity {
 
   @Id

--- a/src/main/java/synapps/resona/api/mysql/socialMedia/entity/feed/Location.java
+++ b/src/main/java/synapps/resona/api/mysql/socialMedia/entity/feed/Location.java
@@ -10,11 +10,13 @@ import jakarta.persistence.OneToOne;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLRestriction;
 import synapps.resona.api.global.entity.BaseEntity;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLRestriction("is_deleted = false")
 public class Location extends BaseEntity {
 
   @Id

--- a/src/main/java/synapps/resona/api/mysql/socialMedia/entity/feed/Scrap.java
+++ b/src/main/java/synapps/resona/api/mysql/socialMedia/entity/feed/Scrap.java
@@ -12,12 +12,14 @@ import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLRestriction;
 import synapps.resona.api.global.entity.BaseEntity;
 import synapps.resona.api.mysql.member.entity.member.Member;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLRestriction("is_deleted = false")
 public class Scrap extends BaseEntity {
 
   @Id

--- a/src/main/java/synapps/resona/api/mysql/socialMedia/entity/media/FeedMedia.java
+++ b/src/main/java/synapps/resona/api/mysql/socialMedia/entity/media/FeedMedia.java
@@ -14,12 +14,14 @@ import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLRestriction;
 import synapps.resona.api.global.entity.BaseEntity;
 import synapps.resona.api.mysql.socialMedia.entity.feed.Feed;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLRestriction("is_deleted = false")
 public class FeedMedia extends BaseEntity {
 
   @Id

--- a/src/main/java/synapps/resona/api/mysql/socialMedia/entity/mention/Mention.java
+++ b/src/main/java/synapps/resona/api/mysql/socialMedia/entity/mention/Mention.java
@@ -12,6 +12,7 @@ import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLRestriction;
 import synapps.resona.api.global.entity.BaseEntity;
 import synapps.resona.api.mysql.member.entity.member.Member;
 import synapps.resona.api.mysql.socialMedia.entity.comment.Comment;
@@ -19,6 +20,7 @@ import synapps.resona.api.mysql.socialMedia.entity.comment.Comment;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLRestriction("is_deleted = false")
 public class Mention extends BaseEntity {
 
   @Id

--- a/src/test/java/synapps/resona/api/mysql/member/service/ProfileServiceTest.java
+++ b/src/test/java/synapps/resona/api/mysql/member/service/ProfileServiceTest.java
@@ -1,6 +1,7 @@
 package synapps.resona.api.mysql.member.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import jakarta.transaction.Transactional;
 import java.time.LocalDateTime;
@@ -26,6 +27,7 @@ import synapps.resona.api.mysql.member.entity.profile.CountryCode;
 import synapps.resona.api.mysql.member.entity.profile.Gender;
 import synapps.resona.api.mysql.member.entity.profile.Language;
 import synapps.resona.api.mysql.member.entity.profile.Profile;
+import synapps.resona.api.mysql.member.exception.ProfileException;
 import synapps.resona.api.mysql.member.repository.account.AccountInfoRepository;
 import synapps.resona.api.mysql.member.repository.member.MemberRepository;
 import synapps.resona.api.oauth.entity.ProviderType;
@@ -186,8 +188,9 @@ class ProfileServiceTest extends IntegrationTestSupport {
   }
 
   @Test
-  @DisplayName("프로필 삭제 시 softDelete 되어야 한다.")
+  @DisplayName("프로필 삭제 시 softDelete 되어야 하며, 더 이상 조회되지 않아야 한다.")
   void deleteProfile() {
+    // given
     ProfileRequest request = new ProfileRequest(
         "삭제닉네임",
         CountryCode.fromCode("kr"),
@@ -202,10 +205,13 @@ class ProfileServiceTest extends IntegrationTestSupport {
     );
     profileService.register(request);
 
+    // when
     profileService.deleteProfile();
 
-    ProfileResponse result = profileService.readProfile();
-    assertThat(result.getNickname()).isEqualTo("삭제닉네임");
+    // then
+    assertThrows(ProfileException.class, () -> {
+      profileService.readProfile();
+    });
   }
 
   @Test


### PR DESCRIPTION
## 📌 개요

- 데이터의 일관성 유지를 위해 논리적 삭제(Soft-delete)가 적용된 데이터가 기본적으로 조회되지 않도록, 프로젝트의 모든 엔티티에 `@SQLRestriction("is_deleted = false")`를 일괄 적용했습니다.
- 이로 인해 영향을 받는 `Profile` 관련 테스트 코드를 수정하여 정상적으로 모든 테스트가 통과되도록 변경했습니다.
    
## 🛠️ 작업 내용

- [x] 모든 도메인 엔티티에 `@SQLRestriction` 어노테이션 추가 
- [x] `@SQLRestriction` 적용으로 인해 실패하는 `Profile` 테스트 코드 수정
   

### `@SQLRestriction` 전역 적용

- `BaseEntity`를 상속받는 모든 `@Entity`에 `@SQLRestriction("is_deleted = false")`를 추가했습니다.
- 이를 통해 JPA 조회 시 `WHERE is_deleted = false` 조건이 모든 쿼리에 자동으로 포함되어, 비즈니스 로직에서 삭제 여부를 검증하는 코드를 최소화하고 실수를 방지할 수 있습니다.

|적용 전 (서비스 코드 예시)|적용 후 (엔티티)|
|---|---|
|`memberRepository.findByIdAndIsDeletedFalse(id)`|`@SQLRestriction("is_deleted = false")`<br/>`public class Member extends BaseEntity`|

### `Profile` 테스트 코드 수정

- 기존 `Profile` 테스트는 논리적 삭제 상태를 고려하지 않고 작성되어 있었습니다.
- 전역으로 `@SQLRestriction`이 적용됨에 따라, Soft-delete된 엔티티가 조회되지 않는 상황을 테스트 케이스에 반영하여 수정했습니다.

## 📌 차후 계획 (Optional)
- 이번 리팩토링으로 엔티티 조회에 대한 기본 정책이 수립되었습니다. 앞으로 새로운 엔티티를 추가할 때도 `is_deleted` 필드와 `@SQLRestriction`을 함께 추가하는 컨벤션을 유지할 계획입니다.
- 관리자 페이지 등에서 삭제된 데이터를 조회해야 할 필요가 생긴다면, 해당 기능은 `@SQLRestriction`을 우회하는 별도의 네이티브 쿼리나 다른 조회 기술을 사용할 예정입니다.

## 📌 테스트 케이스
- [x] 기능 정상 동작 확인
- [x] 새로운 의존성 추가 여부 확인 (`package.json`, `build.gradle` 등)
- [x] 코드 스타일 및 컨벤션 준수 확인
- [x] 기존 테스트 통과 여부 확인
    

- JPA Repository의 기본 `findById`, `findAll` 등의 메소드 호출 시 `is_deleted = true`인 데이터가 제외되는 것을 단위 테스트로 확인했습니다.
- `Profile` 도메인을 포함한 모든 테스트 스위트가 정상적으로 통과하는 것을 CI를 통해 검증했습니다.

### 📌 기타 참고 사항

#### 📌 리뷰어가 확인해야 할 추가 내용, 고민한 점, 결정 과정 등

- 처음에는 `@MappedSuperclass`인 `BaseEntity`에 `@SQLRestriction`을 적용하여 한번에 해결하려 했으나, 해당 어노테이션이 `@Entity`에만 적용되는 제약사항을 확인하고 각 엔티티에 개별적으로 적용하는 것으로 결정했습니다.

---

#### 🙏🏻아래와 같이 PR을 리뷰해주세요.

- PR 내용이 부족하다면 보충 요청해주세요.
- 코드 스타일이 팀의 규칙에 맞게 작성되었는지, 일관성을 유지하고 있는지 확인해주세요.
- 코드에 대한 문서화나 주석이 필요한 부분에 적절하게 작성되어 있는지 확인해주세요.
- 구현된 로직이 효율적이고 올바르게 작성되었는지, 아키텍처를 잘 준수하고 있는지 검토해주세요.
- 네이밍, 포매팅, 주석 등 코드의 일관성이 유지되고 있는지 확인해주세요.

Closes #222