### PR TITLE
[Refactor] 소셜/일반 로그인 계정 통합을 위한 인증 시스템 리팩토링

### DIFF
--- a/src/main/java/synapps/resona/api/global/filter/TokenAuthenticationFilter.java
+++ b/src/main/java/synapps/resona/api/global/filter/TokenAuthenticationFilter.java
@@ -18,23 +18,20 @@ import org.springframework.http.MediaType;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.util.AntPathMatcher;
 import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 import synapps.resona.api.global.config.server.ServerInfoConfig;
 import synapps.resona.api.global.dto.RequestInfo;
 import synapps.resona.api.global.dto.response.ErrorResponse;
-import synapps.resona.api.global.error.GlobalErrorCode;
 import synapps.resona.api.global.utils.HeaderUtil;
 import synapps.resona.api.mysql.member.code.AuthErrorCode;
-import synapps.resona.api.mysql.member.entity.account.AccountInfo; // Import 추가
-import synapps.resona.api.mysql.member.entity.member.Member; // Import 추가
+import synapps.resona.api.mysql.member.entity.member.Member;
 import synapps.resona.api.mysql.member.exception.MemberException;
-import synapps.resona.api.mysql.member.repository.member.MemberRepository; // Import 추가
+import synapps.resona.api.mysql.member.repository.member.MemberRepository;
 import synapps.resona.api.mysql.token.AuthToken;
 import synapps.resona.api.mysql.token.AuthTokenProvider;
-import synapps.resona.api.oauth.entity.UserPrincipal; // Import 추가
+import synapps.resona.api.oauth.entity.UserPrincipal;
 
 @RequiredArgsConstructor
 public class TokenAuthenticationFilter extends OncePerRequestFilter {
@@ -80,11 +77,10 @@ public class TokenAuthenticationFilter extends OncePerRequestFilter {
           Claims claims = token.getTokenClaims();
           String email = claims.getSubject();
 
-          Member member = memberRepository.findByEmailWithAccountInfo(email)
+          Member member = memberRepository.findWithAccountInfoByEmail(email)
               .orElseThrow(MemberException::memberNotFound);
-          AccountInfo accountInfo = member.getAccountInfo();
 
-          UserPrincipal userPrincipal = UserPrincipal.create(member, accountInfo);
+          UserPrincipal userPrincipal = UserPrincipal.create(member);
 
           Authentication authentication = new UsernamePasswordAuthenticationToken(
               userPrincipal,
@@ -120,7 +116,6 @@ public class TokenAuthenticationFilter extends OncePerRequestFilter {
       if (!request.getRequestURI().equals("/api/v1/actuator/prometheus")) {
         logger.warn("No token found in request headers, uri: {}", request.getRequestURI());
       }
-      // SecurityContextHolder.clearContext(); // 주석 처리 또는 제거: 토큰이 없을 때 익명 사용자로 처리되도록 함
     }
 
     filterChain.doFilter(request, response);

--- a/src/main/java/synapps/resona/api/mysql/member/dto/response/MemberInfoDto.java
+++ b/src/main/java/synapps/resona/api/mysql/member/dto/response/MemberInfoDto.java
@@ -21,7 +21,7 @@ public class MemberInfoDto {
   private String roleType;
   private String accountStatus;
   private String lastAccessedAt;
-  private String providerType;
+//  private String providerType;
 
   // Member Details
   private Integer timezone;
@@ -58,7 +58,6 @@ public class MemberInfoDto {
     public MemberInfoDtoBuilder applyAccountInfo(AccountInfo info) {
       this.roleType = safeToString(info != null ? info.getRoleType() : null);
       this.accountStatus = safeToString(info != null ? info.getStatus() : null);
-      this.providerType = safeToString(info != null ? info.getProviderType() : null);
       return this;
     }
 

--- a/src/main/java/synapps/resona/api/mysql/member/entity/account/AccountInfo.java
+++ b/src/main/java/synapps/resona/api/mysql/member/entity/account/AccountInfo.java
@@ -1,19 +1,12 @@
 package synapps.resona.api.mysql.member.entity.account;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
+import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.SQLRestriction;
 import synapps.resona.api.global.entity.BaseEntity;
-import synapps.resona.api.oauth.entity.ProviderType;
 
 @Entity
 @Getter
@@ -33,27 +26,22 @@ public class AccountInfo extends BaseEntity {
 
   @Enumerated(EnumType.STRING)
   @NotNull
-  @Column(name = "provider_type")
-  private ProviderType providerType;
-
-  @Enumerated(EnumType.STRING)
-  @NotNull
   @Column(name = "account_status")
   private AccountStatus status;
 
-  private AccountInfo(RoleType roleType, ProviderType providerType, AccountStatus status) {
+  private AccountInfo(RoleType roleType, AccountStatus status) {
     this.roleType = roleType;
-    this.providerType = providerType;
     this.status = status;
   }
 
-  public static AccountInfo of(RoleType roleType, ProviderType providerType, AccountStatus status) {
-    return new AccountInfo(roleType, providerType, status);
+  public static AccountInfo of(RoleType roleType, AccountStatus status) {
+    return new AccountInfo(roleType, status);
   }
 
   public static AccountInfo empty() {
-    return new AccountInfo(RoleType.GUEST, ProviderType.LOCAL, AccountStatus.TEMPORARY);
+    return new AccountInfo(RoleType.GUEST, AccountStatus.TEMPORARY);
   }
+
 
   public void updateStatus(AccountStatus accountStatus) {
     this.status = accountStatus;
@@ -71,5 +59,4 @@ public class AccountInfo extends BaseEntity {
   public boolean isAccountTemporary() {
     return this.status.equals(AccountStatus.TEMPORARY);
   }
-
 }

--- a/src/main/java/synapps/resona/api/mysql/member/entity/member/Member.java
+++ b/src/main/java/synapps/resona/api/mysql/member/entity/member/Member.java
@@ -34,7 +34,6 @@ import synapps.resona.api.mysql.socialMedia.entity.mention.Mention;
 import synapps.resona.api.mysql.socialMedia.entity.comment.Comment;
 import synapps.resona.api.mysql.socialMedia.entity.feed.Feed;
 import synapps.resona.api.mysql.socialMedia.entity.feed.Scrap;
-import synapps.resona.api.mysql.socialMedia.entity.report.FeedReport;
 import synapps.resona.api.mysql.socialMedia.entity.report.Report;
 import synapps.resona.api.mysql.socialMedia.entity.restriction.Block;
 import synapps.resona.api.mysql.socialMedia.entity.restriction.Hide;
@@ -86,6 +85,9 @@ public class Member extends BaseEntity {
   @OneToMany(mappedBy = "member")
   private final List<Hide> hiddenContents = new ArrayList<>();
 
+  @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
+  private final List<MemberProvider> providers = new ArrayList<>();
+
   @NotBlank
   @Size(max = 50)
   @Email
@@ -95,7 +97,6 @@ public class Member extends BaseEntity {
   private String password;
 
   @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.PERSIST)
-  @JoinColumn(name = "account_info_id")
   private AccountInfo accountInfo;
 
   @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.PERSIST)
@@ -162,5 +163,9 @@ public class Member extends BaseEntity {
 
   public void addNotificationSetting(MemberNotificationSetting memberNotificationSetting) {
     this.notificationSetting = memberNotificationSetting;
+  }
+
+  public void addProvider(MemberProvider provider) {
+    providers.add(provider);
   }
 }

--- a/src/main/java/synapps/resona/api/mysql/member/entity/member/MemberProvider.java
+++ b/src/main/java/synapps/resona/api/mysql/member/entity/member/MemberProvider.java
@@ -1,0 +1,42 @@
+package synapps.resona.api.mysql.member.entity.member;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLRestriction;
+import synapps.resona.api.global.entity.BaseEntity;
+import synapps.resona.api.oauth.entity.ProviderType;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLRestriction("is_deleted = false")
+public class MemberProvider extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "member_provider_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "provider_type")
+    private ProviderType providerType;
+
+    @Column(name = "provider_id")
+    private String providerId;
+
+    private MemberProvider(Member member, ProviderType providerType, String providerId) {
+        this.member = member;
+        this.providerType = providerType;
+        this.providerId = providerId;
+    }
+
+    public static MemberProvider of(Member member, ProviderType providerType, String providerId) {
+        return new MemberProvider(member, providerType, providerId);
+    }
+}

--- a/src/main/java/synapps/resona/api/mysql/member/repository/member/MemberProviderRepository.java
+++ b/src/main/java/synapps/resona/api/mysql/member/repository/member/MemberProviderRepository.java
@@ -1,0 +1,11 @@
+package synapps.resona.api.mysql.member.repository.member;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import synapps.resona.api.mysql.member.entity.member.MemberProvider;
+import synapps.resona.api.mysql.member.entity.member.Member;
+import synapps.resona.api.oauth.entity.ProviderType;
+import java.util.Optional;
+
+public interface MemberProviderRepository extends JpaRepository<MemberProvider, Long> {
+  Optional<MemberProvider> findByMemberAndProviderType(Member member, ProviderType providerType);
+}

--- a/src/main/java/synapps/resona/api/mysql/member/service/TempTokenService.java
+++ b/src/main/java/synapps/resona/api/mysql/member/service/TempTokenService.java
@@ -43,7 +43,6 @@ public class TempTokenService {
     if (!memberRepository.existsByEmail(email)) {
       AccountInfo accountInfo = AccountInfo.of(
           RoleType.GUEST,
-          ProviderType.LOCAL,
           AccountStatus.TEMPORARY
       );
 

--- a/src/main/java/synapps/resona/api/oauth/service/CustomUserDetailsService.java
+++ b/src/main/java/synapps/resona/api/oauth/service/CustomUserDetailsService.java
@@ -21,7 +21,7 @@ public class CustomUserDetailsService implements UserDetailsService {
   public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
     Member member = memberRepository.findWithAccountInfoByEmail(email)
         .orElseThrow(MemberException::memberNotFound);
-    AccountInfo accountInfo = member.getAccountInfo();
-    return UserPrincipal.create(member, accountInfo);
+
+    return UserPrincipal.create(member);
   }
 }

--- a/src/test/java/synapps/resona/api/mysql/member/service/FollowServiceTest.java
+++ b/src/test/java/synapps/resona/api/mysql/member/service/FollowServiceTest.java
@@ -73,7 +73,7 @@ class FollowServiceTest extends IntegrationTestSupport {
     Member me = memberRepository.findByEmailWithAccountInfo(loginEmail)
         .orElseThrow(() -> new RuntimeException("테스트 유저 'me'를 찾을 수 없습니다."));
 
-    UserPrincipal principal = UserPrincipal.create(me, me.getAccountInfo());
+    UserPrincipal principal = UserPrincipal.create(me);
 
     SecurityContextHolder.getContext().setAuthentication(
         new UsernamePasswordAuthenticationToken(principal, null, principal.getAuthorities()));
@@ -136,7 +136,7 @@ class FollowServiceTest extends IntegrationTestSupport {
     Member third = memberRepository.findByEmailWithAccountInfo(thirdEmail)
         .orElseThrow(() -> new RuntimeException("테스트 유저 'third'를 찾을 수 없습니다."));
 
-    UserPrincipal thirdPrincipal = UserPrincipal.create(third, third.getAccountInfo());
+    UserPrincipal thirdPrincipal = UserPrincipal.create(third);
 
     SecurityContextHolder.getContext().setAuthentication(
         new UsernamePasswordAuthenticationToken(thirdPrincipal, null, thirdPrincipal.getAuthorities())

--- a/src/test/java/synapps/resona/api/mysql/member/service/MemberDetailsServiceTest.java
+++ b/src/test/java/synapps/resona/api/mysql/member/service/MemberDetailsServiceTest.java
@@ -68,7 +68,7 @@ class MemberDetailsServiceTest extends IntegrationTestSupport {
     Member member = memberRepository.findByEmailWithAccountInfo(email)
         .orElseThrow(() -> new RuntimeException("테스트 유저를 찾을 수 없습니다."));
 
-    UserPrincipal principal = UserPrincipal.create(member, member.getAccountInfo());
+    UserPrincipal principal = UserPrincipal.create(member);
 
     UsernamePasswordAuthenticationToken authentication =
         new UsernamePasswordAuthenticationToken(principal, null, principal.getAuthorities());

--- a/src/test/java/synapps/resona/api/mysql/member/service/MemberServiceTest.java
+++ b/src/test/java/synapps/resona/api/mysql/member/service/MemberServiceTest.java
@@ -48,12 +48,10 @@ class MemberServiceTest extends IntegrationTestSupport {
   void setUp() {
     AccountInfo accountInfo = AccountInfo.of(
         RoleType.USER,
-        ProviderType.LOCAL,
         AccountStatus.ACTIVE
     );
     AccountInfo tempAccountInfo = AccountInfo.of(
         RoleType.GUEST,
-        ProviderType.LOCAL,
         AccountStatus.TEMPORARY
     );
 
@@ -86,7 +84,7 @@ class MemberServiceTest extends IntegrationTestSupport {
     Member member = memberRepository.findByEmailWithAccountInfo(email)
         .orElseThrow(() -> new RuntimeException("테스트 유저 '" + email + "'를 찾을 수 없습니다."));
 
-    UserPrincipal principal = UserPrincipal.create(member, member.getAccountInfo());
+    UserPrincipal principal = UserPrincipal.create(member);
 
     UsernamePasswordAuthenticationToken auth = new UsernamePasswordAuthenticationToken(
         principal, null, principal.getAuthorities());

--- a/src/test/java/synapps/resona/api/mysql/member/service/ProfileServiceTest.java
+++ b/src/test/java/synapps/resona/api/mysql/member/service/ProfileServiceTest.java
@@ -50,7 +50,6 @@ class ProfileServiceTest extends IntegrationTestSupport {
   void setUp() {
     AccountInfo accountInfo = AccountInfo.of(
         RoleType.GUEST,
-        ProviderType.LOCAL,
         AccountStatus.TEMPORARY
     );
 
@@ -92,7 +91,7 @@ class ProfileServiceTest extends IntegrationTestSupport {
     Member member = memberRepository.findByEmailWithAccountInfo(email)
         .orElseThrow(() -> new RuntimeException("테스트 유저를 찾을 수 없습니다."));
 
-    UserPrincipal principal = UserPrincipal.create(member, member.getAccountInfo());
+    UserPrincipal principal = UserPrincipal.create(member);
 
     UsernamePasswordAuthenticationToken authentication =
         new UsernamePasswordAuthenticationToken(principal, null, principal.getAuthorities());

--- a/src/test/java/synapps/resona/api/mysql/member/service/TempTokenServiceTest.java
+++ b/src/test/java/synapps/resona/api/mysql/member/service/TempTokenServiceTest.java
@@ -51,7 +51,7 @@ class TempTokenServiceTest extends IntegrationTestSupport {
   @BeforeEach
   void setUp() {
     testEmail = "test@example.com";
-    testAccountInfo = AccountInfo.of(RoleType.GUEST, ProviderType.LOCAL, AccountStatus.TEMPORARY);
+    testAccountInfo = AccountInfo.of(RoleType.GUEST, AccountStatus.TEMPORARY);
     MemberDetails emptyMemberDetails = MemberDetails.empty();
     Profile emptyProfile = Profile.empty();
     testMember = Member.of(testAccountInfo, emptyMemberDetails, emptyProfile, testEmail,

--- a/src/test/java/synapps/resona/api/mysql/socialMedia/repository/comment/CommentRepositoryImplTest.java
+++ b/src/test/java/synapps/resona/api/mysql/socialMedia/repository/comment/CommentRepositoryImplTest.java
@@ -129,7 +129,7 @@ class CommentRepositoryImplTest {
   }
 
   private Member createAndPersistMember(String email, String nickname) {
-    AccountInfo accountInfo = AccountInfo.of(RoleType.USER, ProviderType.LOCAL, AccountStatus.ACTIVE);
+    AccountInfo accountInfo = AccountInfo.of(RoleType.USER, AccountStatus.ACTIVE);
     MemberDetails memberDetails = MemberDetails.empty();
     Profile profile = Profile.of(CountryCode.KR, CountryCode.KR, Set.of(Language.KOREAN), Collections.emptySet(), nickname, "tag_" + nickname, "", "2000-01-01");
     Member member = Member.of(accountInfo, memberDetails, profile, email, "password", LocalDateTime.now());

--- a/src/test/java/synapps/resona/api/mysql/socialMedia/repository/feed/strategy/DefaultFeedQueryStrategyTest.java
+++ b/src/test/java/synapps/resona/api/mysql/socialMedia/repository/feed/strategy/DefaultFeedQueryStrategyTest.java
@@ -216,7 +216,7 @@ class DefaultFeedQueryStrategyTest {
 
 
   private Member createAndPersistMember(String email, String nickname) {
-    AccountInfo accountInfo = AccountInfo.of(RoleType.USER, ProviderType.LOCAL, AccountStatus.ACTIVE);
+    AccountInfo accountInfo = AccountInfo.of(RoleType.USER, AccountStatus.ACTIVE);
     MemberDetails memberDetails = MemberDetails.empty();
     Profile profile = Profile.of(CountryCode.KR, CountryCode.KR, Set.of(Language.KOREAN), Collections.emptySet(), nickname, "tag_" + nickname, "", "2000-01-01");
     Member member = Member.of(accountInfo, memberDetails, profile, email, "password", LocalDateTime.now());

--- a/src/test/java/synapps/resona/api/mysql/socialMedia/repository/feed/strategy/MemberFeedQueryStrategyTest.java
+++ b/src/test/java/synapps/resona/api/mysql/socialMedia/repository/feed/strategy/MemberFeedQueryStrategyTest.java
@@ -186,7 +186,7 @@ class MemberFeedQueryStrategyTest {
 
   // === Helper Methods ===
   private Member createAndPersistMember(String email, String nickname) {
-    AccountInfo accountInfo = AccountInfo.of(RoleType.USER, ProviderType.LOCAL, AccountStatus.ACTIVE);
+    AccountInfo accountInfo = AccountInfo.of(RoleType.USER, AccountStatus.ACTIVE);
     MemberDetails memberDetails = MemberDetails.empty();
     Profile profile = Profile.of(CountryCode.KR, CountryCode.KR, Set.of(Language.KOREAN), Collections.emptySet(), nickname, "tag_" + nickname, "", "2000-01-01");
     Member member = Member.of(accountInfo, memberDetails, profile, email, "password", LocalDateTime.now());

--- a/src/test/java/synapps/resona/api/mysql/socialMedia/service/CommentServiceTest.java
+++ b/src/test/java/synapps/resona/api/mysql/socialMedia/service/CommentServiceTest.java
@@ -55,7 +55,6 @@ class CommentServiceTest extends IntegrationTestSupport {
   void setUp() {
     AccountInfo accountInfo = AccountInfo.of(
         RoleType.USER,
-        synapps.resona.api.oauth.entity.ProviderType.LOCAL,
         AccountStatus.ACTIVE
     );
     member = Member.of(


### PR DESCRIPTION
## 📌 개요

- 기존 시스템에서는 동일한 이메일 주소를 사용하더라도 일반 회원가입과 소셜 로그인(Apple, Google 등)이 별개의 계정으로 취급되어 `OAuthProviderMissMatchException`과 같은 충돌이 발생하는 문제가 있었습니다.
- 이번 리팩토링을 통해 하나의 이메일 계정에 여러 인증 방식을 연동할 수 있도록 데이터 모델과 관련 인증 로직을 전면 수정하여 사용자 경험을 개선하고 시스템 확장성을 확보했습니다.

## 🛠️ 작업 내용

- [x] **데이터 모델 변경**
    - `MemberProvider` 엔티티를 신규 생성하여 사용자와 인증 제공자(Provider) 간의 관계를 관리합니다.
    - `AccountInfo` 엔티티에서 `providerType` 필드를 제거하고, `Member` 엔티티가 `MemberProvider` 목록을 갖도록 1:N 관계로 변경했습니다.
- [x] **인증 로직 수정**
    - `AuthService`, `CustomOAuth2UserService` 등 소셜 로그인 처리 로직을 수정하여, 신규 로그인 시 이메일을 기준으로 기존 계정에 새로운 `Provider`를 연동하도록 변경했습니다.
    - `MemberService`의 `signUp` 로직을 수정하여, 소셜 계정으로 가입한 사용자가 일반 회원가입을 할 경우 새 계정을 만들지 않고 기존 계정에 `LOCAL` 인증 방식과 비밀번호를 추가하도록 변경했습니다.
- [x] **관련 컴포넌트 수정**
    - 데이터 모델 변경에 따라 `UserPrincipal`, `TokenAuthenticationFilter`, `CustomUserDetailsService` 등 Spring Security 관련 클래스들의 생성 및 인증 로직을 수정했습니다.
    - 변경된 로직에 맞춰 관련된 테스트 코드의 컴파일 오류를 해결하고 테스트 의도를 유지하도록 수정했습니다.

### 데이터 모델 구조 변경
- AS-IS: `Member`와 `AccountInfo`가 1:1 관계를 맺고, `AccountInfo`가 단일 `ProviderType`을 가짐으로써 계정 확장에 제약이 있었습니다.
- TO-BE: `Member`를 중심으로 `AccountInfo`(계정 상태)와 `MemberProvider`(인증 수단)가 각각 1:1, 1:N 관계를 맺는 구조로 변경하여 유연성을 확보했습니다.

| 변경 전 (AS-IS)                   | 변경 후 (TO-BE)                                                          |
| ------------------------------ | --------------------------------------------------------------------- |
| `Member` ↔ `AccountInfo` (1:1) | `Member` ↔ `AccountInfo` (1:1) <br> `Member` ↔ `MemberProvider` (1:N) |

## 📌 차후 계획

- 추후 사용자가 자신의 프로필 페이지에서 연결된 소셜 계정 목록을 확인하고 관리할 수 있는 기능 추가를 고려중입니다.

## 📌 테스트 케이스

- [x] 기능 정상 동작 확인
- [x] 새로운 의존성 추가 여부 확인 (`build.gradle` 등)
- [x] 코드 스타일 및 컨벤션 준수 확인
- [x] 기존 테스트 통과 여부 확인

- 통합 인증 로직 검증을 위해 아래 시나리오들을 집중적으로 테스트했습니다.
    1. **소셜 로그인 → 일반 가입**: 구글로 먼저 가입한 후, 동일한 이메일로 일반 회원가입 시도 시 기존 계정에 비밀번호가 설정되며 정상적으로 통합되는지 확인.
    2. **일반 가입 → 소셜 로그인**: 일반 회원가입 후, 동일한 이메일의 애플 계정으로 로그인 시도 시 별도 가입 절차 없이 기존 계정에 연동되며 로그인되는지 확인.
    3. **다중 소셜 연동**: 구글로 가입/로그인 후, 동일 이메일의 애플 계정으로 로그인 시 두 `Provider`가 동일한 `Member`에 정상적으로 연결되는지 확인.
    4. **신규 사용자**: 어떤 방식으로든 신규 사용자가 처음 가입할 때 모든 로직이 정상적으로 동작하는지 확인.

Closes #230