### PR TITLE
[Feature] 메시지 발행 및 채팅방 생성/관리 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -107,6 +107,8 @@ dependencies {
 	// stress test: gatling
 	testImplementation 'io.gatling:gatling-test-framework:3.13.1'
 	testImplementation 'io.gatling.highcharts:gatling-charts-highcharts:3.13.1'
+
+	implementation 'org.springframework.boot:spring-boot-starter-amqp'
 }
 
 tasks.named('test') {

--- a/src/main/java/synapps/resona/api/chat/code/ChatErrorCode.java
+++ b/src/main/java/synapps/resona/api/chat/code/ChatErrorCode.java
@@ -6,7 +6,8 @@ import synapps.resona.api.global.dto.code.ErrorCode;
 public enum ChatErrorCode implements ErrorCode {
   ROOM_NOT_FOUND(HttpStatus.NOT_FOUND, "CHAT001", "Chat room not found"),
   NOT_A_MEMBER(HttpStatus.FORBIDDEN, "CHAT002", "Not a member of this chat room"),
-  SENDER_NOT_FOUND(HttpStatus.NOT_FOUND, "CHAT003", "Sender information not found");
+  SENDER_NOT_FOUND(HttpStatus.NOT_FOUND, "CHAT003", "Sender information not found"),
+  CANNOT_CREATE_ROOM_WITH_SELF(HttpStatus.BAD_REQUEST, "CHAT004", "Cannot create a room with only yourself");
 
   private final String code;
   private final String message;

--- a/src/main/java/synapps/resona/api/chat/code/ChatSuccessCode.java
+++ b/src/main/java/synapps/resona/api/chat/code/ChatSuccessCode.java
@@ -5,7 +5,8 @@ import synapps.resona.api.global.dto.code.SuccessCode;
 
 public enum ChatSuccessCode implements SuccessCode {
   MESSAGE_SENT_SUCCESS(HttpStatus.CREATED, "메시지 전송에 성공하였습니다."),
-  GET_MESSAGES_SUCCESS(HttpStatus.OK, "메시지 목록 조회에 성공하였습니다.");
+  GET_MESSAGES_SUCCESS(HttpStatus.OK, "메시지 목록 조회에 성공하였습니다."),
+  ROOM_CREATED_SUCCESS(HttpStatus.CREATED, "채팅방 생성에 성공하였습니다.");
 
   private final HttpStatus status;
   private final String message;

--- a/src/main/java/synapps/resona/api/chat/controller/ChatRoomController.java
+++ b/src/main/java/synapps/resona/api/chat/controller/ChatRoomController.java
@@ -1,0 +1,65 @@
+package synapps.resona.api.chat.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import synapps.resona.api.chat.code.ChatErrorCode;
+import synapps.resona.api.chat.code.ChatSuccessCode;
+import synapps.resona.api.chat.dto.CreateRoomRequest;
+import synapps.resona.api.chat.entity.ChatRoom;
+import synapps.resona.api.chat.service.ChatRoomService;
+import synapps.resona.api.global.annotation.ApiErrorSpec;
+import synapps.resona.api.global.annotation.ApiSuccessResponse;
+import synapps.resona.api.global.annotation.ErrorCodeSpec;
+import synapps.resona.api.global.annotation.SuccessCodeSpec;
+import synapps.resona.api.global.config.server.ServerInfoConfig;
+import synapps.resona.api.global.dto.RequestInfo;
+import synapps.resona.api.global.dto.response.SuccessResponse;
+import synapps.resona.api.oauth.entity.UserPrincipal;
+
+@Tag(name = "ChatRoom", description = "채팅방 생성 API")
+@RestController
+@RequestMapping("/api/v1/chat/rooms")
+@RequiredArgsConstructor
+public class ChatRoomController {
+
+  private final ChatRoomService chatRoomService;
+  private final ServerInfoConfig serverInfo;
+
+  private RequestInfo createRequestInfo(String path) {
+    return new RequestInfo(serverInfo.getApiVersion(), serverInfo.getServerName(), path);
+  }
+
+  @Operation(summary = "채팅방 생성", description = "새로운 1:1 또는 그룹 채팅방을 생성합니다. (인증 필요)")
+  @ApiSuccessResponse(@SuccessCodeSpec(enumClass = ChatSuccessCode.class, code = "ROOM_CREATED_SUCCESS"))
+  @ApiErrorSpec(@ErrorCodeSpec(enumClass = ChatErrorCode.class, codes = {"CANNOT_CREATE_ROOM_WITH_SELF"}))
+  @PostMapping
+  public ResponseEntity<SuccessResponse<ChatRoom>> createRoom(
+      @AuthenticationPrincipal UserPrincipal userPrincipal,
+      @RequestBody CreateRoomRequest request,
+      HttpServletRequest httpServletRequest
+  ) {
+    Long creatorId = userPrincipal.getMemberId();
+
+    ChatRoom createdRoom = chatRoomService.createChatRoom(
+        creatorId,
+        request.roomName(),
+        request.memberIds()
+    );
+
+    return ResponseEntity
+        .status(ChatSuccessCode.ROOM_CREATED_SUCCESS.getStatus())
+        .body(SuccessResponse.of(
+            ChatSuccessCode.ROOM_CREATED_SUCCESS,
+            createRequestInfo(httpServletRequest.getRequestURI()),
+            createdRoom
+        ));
+  }
+}

--- a/src/main/java/synapps/resona/api/chat/dto/CreateRoomRequest.java
+++ b/src/main/java/synapps/resona/api/chat/dto/CreateRoomRequest.java
@@ -1,0 +1,6 @@
+package synapps.resona.api.chat.dto;
+
+import java.util.List;
+
+public record CreateRoomRequest(String roomName, List<Long> memberIds) {
+}

--- a/src/main/java/synapps/resona/api/chat/dto/MessageDto.java
+++ b/src/main/java/synapps/resona/api/chat/dto/MessageDto.java
@@ -1,50 +1,36 @@
 package synapps.resona.api.chat.dto;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
 import java.time.LocalDateTime;
-import lombok.Builder;
-import lombok.Getter;
 import synapps.resona.api.chat.entity.ChatMessage;
 import synapps.resona.api.chat.entity.ChatMember;
 import synapps.resona.api.chat.entity.MessageType;
 
-@Getter
-@JsonInclude(JsonInclude.Include.NON_NULL)
-public class MessageDto {
-
-  private String msgId;
-  private SenderDto sender;
-  private MessageType type;
-  private String content;
-  private LocalDateTime timestamp;
-
-  // 파일/이미지 관련 정보
-  private String fileUrl;
-  private String fileName;
-  private Long fileSize;
-
-  @Builder
-  private MessageDto(String msgId, SenderDto sender, MessageType type, String content, LocalDateTime timestamp, String fileUrl, String fileName, Long fileSize) {
-    this.msgId = msgId;
-    this.sender = sender;
-    this.type = type;
-    this.content = content;
-    this.timestamp = timestamp;
-    this.fileUrl = fileUrl;
-    this.fileName = fileName;
-    this.fileSize = fileSize;
+public record MessageDto(
+    String msgId,
+    Long roomId,
+    MessageType type,
+    String content,
+    LocalDateTime timestamp,
+    Sender sender
+) {
+  public record Sender(
+      Long id,
+      String nickname,
+      String profileImageUrl
+  ) {
+    public static Sender from(ChatMember member) {
+      return new Sender(member.getId(), member.getNickname(), member.getProfileImageUrl());
+    }
   }
 
-  public static MessageDto of(ChatMessage message, ChatMember member) {
-    return MessageDto.builder()
-        .msgId(message.getMsgId().toHexString())
-        .sender(SenderDto.from(member))
-        .type(message.getType())
-        .content(message.getContent())
-        .timestamp(message.getTimestamp())
-        .fileUrl(message.getFileUrl())
-        .fileName(message.getFileName())
-        .fileSize(message.getFileSize())
-        .build();
+  public static MessageDto of(ChatMessage message, ChatMember member, Long roomId) {
+    return new MessageDto(
+        message.getMsgId().toString(),
+        roomId,
+        message.getType(),
+        message.getContent(),
+        message.getTimestamp(),
+        Sender.from(member)
+    );
   }
 }

--- a/src/main/java/synapps/resona/api/chat/entity/ChatRoom.java
+++ b/src/main/java/synapps/resona/api/chat/entity/ChatRoom.java
@@ -11,6 +11,8 @@ import org.springframework.data.mongodb.core.mapping.Document;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Document(collection = "rooms")
 public class ChatRoom {
+  public static final String SEQUENCE_NAME = "rooms_sequence";
+
   @Id
   private Long id;
 

--- a/src/main/java/synapps/resona/api/chat/entity/DatabaseSequence.java
+++ b/src/main/java/synapps/resona/api/chat/entity/DatabaseSequence.java
@@ -1,0 +1,15 @@
+package synapps.resona.api.chat.entity;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+@Document(collection = "database_sequences")
+@Getter
+@Setter
+public class DatabaseSequence {
+  @Id
+  private String id;
+  private long seq;
+}

--- a/src/main/java/synapps/resona/api/chat/exception/ChatException.java
+++ b/src/main/java/synapps/resona/api/chat/exception/ChatException.java
@@ -23,4 +23,8 @@ public class ChatException extends BaseException {
   public static ChatException senderNotFound() {
     return ChatException.of(ChatErrorCode.SENDER_NOT_FOUND);
   }
+
+  public static ChatException cannotCreateRoomWithSelf() {
+    return ChatException.of(ChatErrorCode.CANNOT_CREATE_ROOM_WITH_SELF);
+  }
 }

--- a/src/main/java/synapps/resona/api/chat/service/ChatMessagePublisher.java
+++ b/src/main/java/synapps/resona/api/chat/service/ChatMessagePublisher.java
@@ -1,0 +1,36 @@
+package synapps.resona.api.chat.service;
+
+import static synapps.resona.api.global.config.database.RabbitMQConfig.CHAT_EXCHANGE_NAME;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.stereotype.Service;
+import synapps.resona.api.chat.dto.MessageDto;
+import synapps.resona.api.chat.entity.ChatMessage;
+import synapps.resona.api.chat.entity.ChatMember;
+import synapps.resona.api.chat.exception.ChatException;
+import synapps.resona.api.chat.repository.ChatMemberRepository;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ChatMessagePublisher {
+
+  private final RabbitTemplate rabbitTemplate;
+
+  private static final String ROUTING_KEY_PREFIX = "room.";
+
+  public void publish(ChatMessage message, ChatMember sender, Long roomId) {
+    MessageDto messageDto = MessageDto.of(message, sender, roomId);
+
+    String routingKey = ROUTING_KEY_PREFIX + roomId;
+
+    try {
+      rabbitTemplate.convertAndSend(CHAT_EXCHANGE_NAME, routingKey, messageDto);
+      log.info("Message published to exchange '{}' with routing key '{}'. Message: {}", CHAT_EXCHANGE_NAME, routingKey, messageDto);
+    } catch (Exception e) {
+      log.error("Failed to publish message to RabbitMQ. Exchange: {}, RoutingKey: {}. Error: {}", CHAT_EXCHANGE_NAME, routingKey, e.getMessage());
+    }
+  }
+}

--- a/src/main/java/synapps/resona/api/chat/service/ChatMessagePublisher.java
+++ b/src/main/java/synapps/resona/api/chat/service/ChatMessagePublisher.java
@@ -3,19 +3,18 @@ package synapps.resona.api.chat.service;
 import static synapps.resona.api.global.config.database.RabbitMQConfig.CHAT_EXCHANGE_NAME;
 
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.stereotype.Service;
 import synapps.resona.api.chat.dto.MessageDto;
 import synapps.resona.api.chat.entity.ChatMessage;
 import synapps.resona.api.chat.entity.ChatMember;
-import synapps.resona.api.chat.exception.ChatException;
-import synapps.resona.api.chat.repository.ChatMemberRepository;
 
-@Slf4j
 @Service
 @RequiredArgsConstructor
 public class ChatMessagePublisher {
+  private final Logger logger = LogManager.getLogger(ChatMessagePublisher.class);
 
   private final RabbitTemplate rabbitTemplate;
 
@@ -28,9 +27,9 @@ public class ChatMessagePublisher {
 
     try {
       rabbitTemplate.convertAndSend(CHAT_EXCHANGE_NAME, routingKey, messageDto);
-      log.info("Message published to exchange '{}' with routing key '{}'. Message: {}", CHAT_EXCHANGE_NAME, routingKey, messageDto);
+      logger.info("Message published to exchange '{}' with routing key '{}'. Message: {}", CHAT_EXCHANGE_NAME, routingKey, messageDto);
     } catch (Exception e) {
-      log.error("Failed to publish message to RabbitMQ. Exchange: {}, RoutingKey: {}. Error: {}", CHAT_EXCHANGE_NAME, routingKey, e.getMessage());
+      logger.error("Failed to publish message to RabbitMQ. Exchange: {}, RoutingKey: {}. Error: {}", CHAT_EXCHANGE_NAME, routingKey, e.getMessage());
     }
   }
 }

--- a/src/main/java/synapps/resona/api/chat/service/ChatRoomService.java
+++ b/src/main/java/synapps/resona/api/chat/service/ChatRoomService.java
@@ -1,0 +1,39 @@
+package synapps.resona.api.chat.service;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import synapps.resona.api.chat.entity.ChatRoom;
+import synapps.resona.api.chat.exception.ChatException;
+import synapps.resona.api.chat.repository.RoomRepository;
+
+@Service
+@RequiredArgsConstructor
+public class ChatRoomService {
+
+  private final RoomRepository roomRepository;
+  private final SequenceGeneratorService sequenceGenerator;
+
+  @Transactional
+  public ChatRoom createChatRoom(Long creatorId, String roomName, List<Long> inviteeIds) {
+    // 자기 자신만 있는 채팅방은 생성 불가
+    if (inviteeIds == null || inviteeIds.isEmpty()) {
+      throw ChatException.cannotCreateRoomWithSelf();
+    }
+
+
+    Set<Long> memberIdSet = new HashSet<>(inviteeIds);
+    memberIdSet.add(creatorId);
+    List<Long> finalMemberIds = new ArrayList<>(memberIdSet);
+
+    long roomId = sequenceGenerator.generateSequence(ChatRoom.SEQUENCE_NAME);
+
+    ChatRoom newRoom = ChatRoom.of(roomId, roomName, finalMemberIds);
+
+    return roomRepository.save(newRoom);
+  }
+}

--- a/src/main/java/synapps/resona/api/chat/service/SequenceGeneratorService.java
+++ b/src/main/java/synapps/resona/api/chat/service/SequenceGeneratorService.java
@@ -1,0 +1,29 @@
+package synapps.resona.api.chat.service;
+
+import static org.springframework.data.mongodb.core.FindAndModifyOptions.options;
+import static org.springframework.data.mongodb.core.query.Criteria.where;
+import static org.springframework.data.mongodb.core.query.Query.query;
+
+import java.util.Objects;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.mongodb.core.MongoOperations;
+import org.springframework.data.mongodb.core.query.Update;
+import org.springframework.stereotype.Service;
+import synapps.resona.api.chat.entity.DatabaseSequence;
+
+@Service
+@RequiredArgsConstructor
+public class SequenceGeneratorService {
+
+  private final MongoOperations mongoOperations;
+
+  public long generateSequence(String seqName) {
+    DatabaseSequence counter = mongoOperations.findAndModify(
+        query(where("_id").is(seqName)),
+        new Update().inc("seq", 1),
+        options().returnNew(true).upsert(true),
+        DatabaseSequence.class
+    );
+    return !Objects.isNull(counter) ? counter.getSeq() : 1;
+  }
+}

--- a/src/main/java/synapps/resona/api/global/config/database/RabbitMQConfig.java
+++ b/src/main/java/synapps/resona/api/global/config/database/RabbitMQConfig.java
@@ -1,0 +1,47 @@
+package synapps.resona.api.global.config.database;
+
+import org.springframework.amqp.core.TopicExchange;
+import org.springframework.amqp.rabbit.connection.ConnectionFactory;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
+import org.springframework.amqp.support.converter.MessageConverter;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class RabbitMQConfig {
+
+  // Exchange 이름 정의
+  public static final String CHAT_EXCHANGE_NAME = "chat.exchange";
+
+  /**
+   * - TopicExchange Bean 생성
+   * - chat.exchange라는 이름으로 생성
+   */
+  @Bean
+  public TopicExchange chatExchange() {
+    return new TopicExchange(CHAT_EXCHANGE_NAME);
+  }
+
+  /**
+   * - RabbitTemplate이 메시지를 전송할 때 사용할 MessageConverter를 설정
+   * - 여기서는 Jackson2JsonMessageConverter를 사용하여 객체를 JSON 형태로 직렬화
+   * - 다양한 컨슈머(Consumer)가 메시지 포맷에 구애받지 않고 쉽게 파싱할 수 있음
+   */
+  @Bean
+  public MessageConverter jsonMessageConverter() {
+    return new Jackson2JsonMessageConverter();
+  }
+
+  /**
+   * RabbitMQ 메시지 발행(publish) 및 수신(receive)을 위한 기본 템플릿 설정
+   * 위에서 정의한 jsonMessageConverter를 사용하도록 설정
+   * DTO 객체를 보낼 때 자동으로 JSON으로 변환
+   */
+  @Bean
+  public RabbitTemplate rabbitTemplate(ConnectionFactory connectionFactory) {
+    RabbitTemplate rabbitTemplate = new RabbitTemplate(connectionFactory);
+    rabbitTemplate.setMessageConverter(jsonMessageConverter());
+    return rabbitTemplate;
+  }
+}

--- a/src/main/java/synapps/resona/api/matching/code/MatchingErrorCode.java
+++ b/src/main/java/synapps/resona/api/matching/code/MatchingErrorCode.java
@@ -1,0 +1,38 @@
+package synapps.resona.api.matching.code;
+
+import org.springframework.http.HttpStatus;
+import synapps.resona.api.global.dto.code.ErrorCode;
+
+public enum MatchingErrorCode implements ErrorCode {
+  MATCHING_FAILED(HttpStatus.NOT_FOUND, "MATCH001", "Cannot find chat partner.");
+
+  private final String code;
+  private final String message;
+  private final HttpStatus status;
+
+  MatchingErrorCode(final HttpStatus status, final String code, final String message) {
+    this.code = code;
+    this.status = status;
+    this.message = message;
+  }
+
+  @Override
+  public HttpStatus getStatus() {
+    return this.status;
+  }
+
+  @Override
+  public String getMessage() {
+    return this.message;
+  }
+
+  @Override
+  public int getStatusCode() {
+    return status.value();
+  }
+
+  @Override
+  public String getCustomCode() {
+    return this.code;
+  }
+}

--- a/src/main/java/synapps/resona/api/matching/code/MatchingSuccessCode.java
+++ b/src/main/java/synapps/resona/api/matching/code/MatchingSuccessCode.java
@@ -1,0 +1,31 @@
+package synapps.resona.api.matching.code;
+
+import org.springframework.http.HttpStatus;
+import synapps.resona.api.global.dto.code.SuccessCode;
+
+public enum MatchingSuccessCode implements SuccessCode {
+  MATCHING_SUCCESS(HttpStatus.CREATED, "매칭에 성공하고 채팅방을 생성했습니다.");
+
+  private final HttpStatus status;
+  private final String message;
+
+  MatchingSuccessCode(HttpStatus status, String message) {
+    this.status = status;
+    this.message = message;
+  }
+
+  @Override
+  public HttpStatus getStatus() {
+    return this.status;
+  }
+
+  @Override
+  public String getMessage() {
+    return this.message;
+  }
+
+  @Override
+  public int getStatusCode() {
+    return this.status.value();
+  }
+}

--- a/src/main/java/synapps/resona/api/matching/controller/MatchingController.java
+++ b/src/main/java/synapps/resona/api/matching/controller/MatchingController.java
@@ -1,4 +1,4 @@
-package synapps.resona.api.chat.controller;
+package synapps.resona.api.matching.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -7,14 +7,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-import synapps.resona.api.chat.code.ChatErrorCode;
-import synapps.resona.api.chat.code.ChatSuccessCode;
-import synapps.resona.api.chat.dto.CreateRoomRequest;
 import synapps.resona.api.chat.entity.ChatRoom;
-import synapps.resona.api.chat.service.ChatRoomService;
 import synapps.resona.api.global.annotation.ApiErrorSpec;
 import synapps.resona.api.global.annotation.ApiSuccessResponse;
 import synapps.resona.api.global.annotation.ErrorCodeSpec;
@@ -22,42 +17,39 @@ import synapps.resona.api.global.annotation.SuccessCodeSpec;
 import synapps.resona.api.global.config.server.ServerInfoConfig;
 import synapps.resona.api.global.dto.RequestInfo;
 import synapps.resona.api.global.dto.response.SuccessResponse;
+import synapps.resona.api.matching.code.MatchingErrorCode;
+import synapps.resona.api.matching.code.MatchingSuccessCode;
+import synapps.resona.api.matching.service.MatchingService;
 import synapps.resona.api.oauth.entity.UserPrincipal;
 
-@Tag(name = "ChatRoom", description = "채팅방 생성 API")
+@Tag(name = "Matching", description = "사용자 매칭 및 채팅방 자동 생성 API")
 @RestController
-@RequestMapping("/chat/rooms")
+@RequestMapping("/matches")
 @RequiredArgsConstructor
-public class ChatRoomController {
+public class MatchingController {
 
-  private final ChatRoomService chatRoomService;
+  private final MatchingService matchingService;
   private final ServerInfoConfig serverInfo;
 
   private RequestInfo createRequestInfo(String path) {
     return new RequestInfo(serverInfo.getApiVersion(), serverInfo.getServerName(), path);
   }
 
-  @Operation(summary = "채팅방 생성", description = "새로운 1:1 또는 그룹 채팅방을 생성합니다. (인증 필요)")
-  @ApiSuccessResponse(@SuccessCodeSpec(enumClass = ChatSuccessCode.class, code = "ROOM_CREATED_SUCCESS"))
-  @ApiErrorSpec(@ErrorCodeSpec(enumClass = ChatErrorCode.class, codes = {"CANNOT_CREATE_ROOM_WITH_SELF"}))
+  @Operation(summary = "매칭 요청 및 채팅방 생성", description = "매칭을 요청하고, 성공 시 자동으로 채팅방을 생성합니다.")
+  @ApiSuccessResponse(@SuccessCodeSpec(enumClass = MatchingSuccessCode.class, code = "MATCHING_SUCCESS"))
+  @ApiErrorSpec(@ErrorCodeSpec(enumClass = MatchingErrorCode.class, codes = {"MATCHING_FAILED"}))
   @PostMapping
-  public ResponseEntity<SuccessResponse<ChatRoom>> createRoom(
+  public ResponseEntity<SuccessResponse<ChatRoom>> requestMatch(
       @AuthenticationPrincipal UserPrincipal userPrincipal,
-      @RequestBody CreateRoomRequest request,
       HttpServletRequest httpServletRequest
   ) {
-    Long creatorId = userPrincipal.getMemberId();
-
-    ChatRoom createdRoom = chatRoomService.createChatRoom(
-        creatorId,
-        request.roomName(),
-        request.memberIds()
-    );
+    Long requesterId = userPrincipal.getMemberId();
+    ChatRoom createdRoom = matchingService.processMatchAndCreateRoom(requesterId);
 
     return ResponseEntity
-        .status(ChatSuccessCode.ROOM_CREATED_SUCCESS.getStatus())
+        .status(MatchingSuccessCode.MATCHING_SUCCESS.getStatus())
         .body(SuccessResponse.of(
-            ChatSuccessCode.ROOM_CREATED_SUCCESS,
+            MatchingSuccessCode.MATCHING_SUCCESS,
             createRequestInfo(httpServletRequest.getRequestURI()),
             createdRoom
         ));

--- a/src/main/java/synapps/resona/api/matching/dto/MatchResult.java
+++ b/src/main/java/synapps/resona/api/matching/dto/MatchResult.java
@@ -1,0 +1,16 @@
+package synapps.resona.api.matching.dto;
+
+import java.util.List;
+
+public record MatchResult(
+    boolean isSuccess,
+    List<Long> matchedMemberIds
+) {
+  public static MatchResult success(List<Long> memberIds) {
+    return new MatchResult(true, memberIds);
+  }
+
+  public static MatchResult failure() {
+    return new MatchResult(false, List.of());
+  }
+}

--- a/src/main/java/synapps/resona/api/matching/exception/MatchingException.java
+++ b/src/main/java/synapps/resona/api/matching/exception/MatchingException.java
@@ -1,0 +1,21 @@
+package synapps.resona.api.matching.exception;
+
+import org.springframework.http.HttpStatus;
+import synapps.resona.api.global.error.exception.BaseException;
+import synapps.resona.api.matching.code.MatchingErrorCode;
+
+public class MatchingException extends BaseException {
+
+  protected MatchingException(String message, HttpStatus status,
+      String errorCode) {
+    super(message, status, errorCode);
+  }
+
+  private static MatchingException of(MatchingErrorCode errorCode) {
+    return new MatchingException(errorCode.getMessage(), errorCode.getStatus(), errorCode.getCustomCode());
+  }
+
+  public static MatchingException matchFailed() {
+    return of(MatchingErrorCode.MATCHING_FAILED);
+  }
+}

--- a/src/main/java/synapps/resona/api/matching/service/MatchingService.java
+++ b/src/main/java/synapps/resona/api/matching/service/MatchingService.java
@@ -1,0 +1,43 @@
+package synapps.resona.api.matching.service;
+
+import lombok.RequiredArgsConstructor;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import synapps.resona.api.chat.entity.ChatRoom;
+import synapps.resona.api.chat.service.ChatMessagePublisher;
+import synapps.resona.api.chat.service.ChatRoomService;
+import synapps.resona.api.matching.dto.MatchResult;
+import synapps.resona.api.matching.exception.MatchingException;
+import synapps.resona.api.matching.strategy.MatchingStrategy;
+
+@Service
+@RequiredArgsConstructor
+public class MatchingService {
+  private final Logger logger = LogManager.getLogger(MatchingService.class);
+
+  private final ChatRoomService chatRoomService;
+  private final MatchingStrategy matchingStrategy;
+
+  @Transactional
+  public ChatRoom processMatchAndCreateRoom(Long requesterId) {
+    MatchResult result = matchingStrategy.match(requesterId);
+
+    if (!result.isSuccess() || result.matchedMemberIds().size() < 2) {
+      throw MatchingException.matchFailed();
+    }
+
+    String roomName = "새로운 채팅방";
+
+    ChatRoom createdRoom = chatRoomService.createChatRoom(
+        requesterId,
+        roomName,
+        result.matchedMemberIds()
+    );
+
+    logger.info("자동으로 채팅방이 생성되었습니다. Room ID: {}", createdRoom.getId());
+
+    return createdRoom;
+  }
+}

--- a/src/main/java/synapps/resona/api/matching/strategy/MatchingStrategy.java
+++ b/src/main/java/synapps/resona/api/matching/strategy/MatchingStrategy.java
@@ -1,0 +1,7 @@
+package synapps.resona.api.matching.strategy;
+
+import synapps.resona.api.matching.dto.MatchResult;
+
+public interface MatchingStrategy {
+  MatchResult match(Long requesterId);
+}

--- a/src/main/java/synapps/resona/api/matching/strategy/RandomMatchingStrategy.java
+++ b/src/main/java/synapps/resona/api/matching/strategy/RandomMatchingStrategy.java
@@ -1,0 +1,23 @@
+package synapps.resona.api.matching.strategy;
+
+import java.util.List;
+import org.springframework.stereotype.Component;
+import synapps.resona.api.matching.dto.MatchResult;
+
+@Component("randomMatching")
+public class RandomMatchingStrategy implements MatchingStrategy {
+
+  @Override
+  public MatchResult match(Long requesterId) {
+    // TODO: 랜덤 매칭 기능 구현
+    System.out.println("랜덤 매칭 전략 실행...");
+
+    // 임시 id
+    Long partnerId = 99L;
+
+    if (partnerId != null) {
+      return MatchResult.success(List.of(requesterId, partnerId));
+    }
+    return MatchResult.failure();
+  }
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -27,6 +27,11 @@ spring:
       authentication-database: ${MONGO_AUTH_DATABASE}
       username: ${MONGO_USERNAME}
       password: ${MONGO_PASSWORD}
+  rabbitmq:
+    host: ${RABBIT_MQ_HOST}
+    port: ${RABBIT_MQ_PORT}
+    username: ${RABBIT_MQ_USERNAME}
+    password: ${RABBIT_MQ_PASSWORD}
   task:
     execution:
       pool:

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -23,6 +23,11 @@ spring:
       authentication-database: ${MONGO_AUTH_DATABASE}
       username: ${MONGO_USERNAME}
       password: ${MONGO_PASSWORD}
+  rabbitmq:
+    host: ${RABBIT_MQ_HOST}
+    port: ${RABBIT_MQ_PORT}
+    username: ${RABBIT_MQ_USERNAME}
+    password: ${RABBIT_MQ_PASSWORD}
   task:
     execution:
       pool:

--- a/src/test/java/synapps/resona/api/chat/service/ChatMessagePublisherTest.java
+++ b/src/test/java/synapps/resona/api/chat/service/ChatMessagePublisherTest.java
@@ -1,0 +1,92 @@
+package synapps.resona.api.chat.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static synapps.resona.api.global.config.database.RabbitMQConfig.CHAT_EXCHANGE_NAME;
+
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.amqp.AmqpException;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import synapps.resona.api.chat.dto.MessageDto;
+import synapps.resona.api.chat.entity.ChatMessage;
+import synapps.resona.api.chat.entity.ChatMember;
+
+@ExtendWith(MockitoExtension.class)
+class ChatMessagePublisherTest {
+
+  @InjectMocks
+  private ChatMessagePublisher chatMessagePublisher;
+
+  @Mock
+  private RabbitTemplate rabbitTemplate;
+
+  @Nested
+  @DisplayName("publish 메서드 테스트")
+  class PublishTests {
+
+    @Test
+    @DisplayName("메시지를 성공적으로 발행한다.")
+    void shouldPublishMessageSuccessfully() {
+      // given
+      Long roomId = 100L;
+      Long senderId = 1L;
+      ChatMember sender = ChatMember.of(senderId, "테스트유저", "profile.jpg");
+      ChatMessage chatMessage = ChatMessage.createTextMessage(senderId, "안녕하세요", LocalDateTime.now());
+
+      // when
+      chatMessagePublisher.publish(chatMessage, sender, roomId);
+
+      // then
+      ArgumentCaptor<String> exchangeCaptor = ArgumentCaptor.forClass(String.class);
+      ArgumentCaptor<String> routingKeyCaptor = ArgumentCaptor.forClass(String.class);
+      ArgumentCaptor<MessageDto> messageDtoCaptor = ArgumentCaptor.forClass(MessageDto.class);
+
+      // rabbitTemplate.convertAndSend 메서드가 정확히 1번 호출되었는지 검증
+      verify(rabbitTemplate, times(1))
+          .convertAndSend(exchangeCaptor.capture(), routingKeyCaptor.capture(), messageDtoCaptor.capture());
+
+      // 캡처된 인자들이 예상과 일치하는지 확인
+      assertThat(exchangeCaptor.getValue()).isEqualTo(CHAT_EXCHANGE_NAME);
+      assertThat(routingKeyCaptor.getValue()).isEqualTo("room." + roomId);
+
+      MessageDto capturedDto = messageDtoCaptor.getValue();
+      assertThat(capturedDto.roomId()).isEqualTo(roomId);
+      assertThat(capturedDto.content()).isEqualTo("안녕하세요");
+      assertThat(capturedDto.sender().id()).isEqualTo(senderId);
+      assertThat(capturedDto.sender().nickname()).isEqualTo("테스트유저");
+    }
+
+    @Test
+    @DisplayName("메시지 발행 중 예외가 발생해도 외부로 전파하지 않는다.")
+    void shouldNotPropagateExceptionOnPublishFailure() {
+      // given
+      Long roomId = 101L;
+      ChatMember sender = ChatMember.of(2L, "에러유저", "error.jpg");
+      ChatMessage chatMessage = ChatMessage.createTextMessage(2L, "에러 메시지", LocalDateTime.now());
+
+      doThrow(new AmqpException("RabbitMQ connection failed"))
+          .when(rabbitTemplate)
+          .convertAndSend(any(String.class), any(String.class), any(MessageDto.class));
+
+      // when & then
+      // publish 메서드 실행 시 어떤 예외도 발생하지 않음을 검증
+      assertThatCode(() -> chatMessagePublisher.publish(chatMessage, sender, roomId))
+          .doesNotThrowAnyException();
+
+      // 예외가 발생했더라도, 메시지 전송 시도는 1번 이루어졌는지 확인
+      verify(rabbitTemplate, times(1)).convertAndSend(any(String.class), any(String.class), any(MessageDto.class));
+    }
+  }
+}

--- a/src/test/java/synapps/resona/api/chat/service/ChatServiceTest.java
+++ b/src/test/java/synapps/resona/api/chat/service/ChatServiceTest.java
@@ -43,10 +43,15 @@ class ChatServiceTest {
 
   @Mock
   private MessageBucketRepository messageBucketRepository;
+
   @Mock
   private RoomRepository roomRepository;
+
   @Mock
   private ChatMemberRepository chatMemberRepository;
+
+  @Mock
+  private ChatMessagePublisher chatMessagePublisher;
 
   @Nested
   @DisplayName("sendMessage 메서드 테스트")
@@ -62,6 +67,9 @@ class ChatServiceTest {
 
       ChatMessage firstMessage = ChatMessage.createTextMessage(memberId, "첫 메시지", LocalDateTime.now());
       MessageBucket existingBucket = MessageBucket.createFirstBucket(roomId, 1, firstMessage);
+
+      ChatMember sender = ChatMember.of(memberId, "테스트유저", "profile.jpg");
+      given(chatMemberRepository.findById(memberId)).willReturn(Optional.of(sender));
 
       given(roomRepository.isMemberInRoom(roomId, memberId)).willReturn(true);
       given(messageBucketRepository.findLatestAvailableBucket(anyLong(), anyInt())).willReturn(Optional.of(existingBucket));
@@ -87,6 +95,9 @@ class ChatServiceTest {
       Long memberId = 1L;
       Long roomId = 100L;
       SendMessageRequest request = new SendMessageRequest("새 버킷 메시지");
+
+      ChatMember sender = ChatMember.of(memberId, "테스트유저", "profile.jpg");
+      given(chatMemberRepository.findById(memberId)).willReturn(Optional.of(sender));
 
       given(roomRepository.isMemberInRoom(roomId, memberId)).willReturn(true);
       given(messageBucketRepository.findLatestAvailableBucket(anyLong(), anyInt())).willReturn(Optional.empty());

--- a/src/test/java/synapps/resona/api/chat/service/ChatServiceTest.java
+++ b/src/test/java/synapps/resona/api/chat/service/ChatServiceTest.java
@@ -158,8 +158,8 @@ class ChatServiceTest {
 
       // then
       assertThat(result.getContent()).hasSize(2);
-      assertThat(result.getContent().get(0).getSender().getNickname()).isEqualTo("사용자2");
-      assertThat(result.getContent().get(1).getContent()).isEqualTo("메시지 1");
+      assertThat(result.getContent().get(0).sender().nickname()).isEqualTo("사용자2");
+      assertThat(result.getContent().get(1).content()).isEqualTo("메시지 1");
     }
 
     @Test


### PR DESCRIPTION
## 📌 개요

- 채팅 메시지를 MongoDB에 저장 후 RabbitMQ로 발행하여 실시간 통신을 지원하는 기반을 구축했습니다.
- 사용자가 직접 채팅방을 생성하는 API와, 사용자 매칭 등 시스템 로직에 의해 채팅방이 자동으로 생성되는 기능 구현을 통해 확장성 있는 채팅방 관리 아키텍처를 설계했습니다.

## 🛠️ 작업 내용

- [x] RabbitMQ 연동을 통한 실시간 메시지 발행 시스템 구축
- [x] MongoDB 환경에서 원자성을 보장하는 순차 ID 생성 전략 구현
- [x] 사용자 주도 채팅방 생성 API (`POST /api/v1/chat/rooms`) 구현
- [x] 시스템 주도(매칭) 채팅방 자동 생성 로직 및 API 구현
- [x] 관련 기능에 대한 단위 테스트 코드 작성 및 컨벤션 통일
- [x] 관련 기능에 필요한 `ErrorCode`, `SuccessCode`, `Exception` 추가

### 실시간 메시지 발행 시스템 구축

- 메시지 처리 흐름 변경: `ChatService`가 메시지를 MongoDB에 저장한 후, `ChatMessagePublisher`를 호출하여 해당 메시지를 RabbitMQ로 발행하도록 흐름을 변경했습니다.
- RabbitMQ 인프라 설정: `chat.exchange`라는 이름의 Topic Exchange를 사용하도록 설정하여 `room.{roomId}` 형태의 라우팅 키로 각 채팅방에 맞는 유연한 메시지 라우팅이 가능하도록 설계했습니다. 또한, `Jackson2JsonMessageConverter`를 MessageConverter로 등록하여 모든 메시지를 JSON 형식으로 직렬화함으로써 확장성과 상호 운용성을 확보했습니다.
- 단위 테스트: `ChatMessagePublisher`가 실제 RabbitMQ 없이도 동작을 검증할 수 있도록 `RabbitTemplate`을 Mocking 하여 단위 테스트를 작성했습니다. `ArgumentCaptor`를 사용해 `convertAndSend` 메서드에 전달되는 `exchange`, `routingKey`, `messageDto`가 정확한지 검증했습니다.
- **인프라 이슈**: RabbitMQ를 OCI에 띄우는 과정에서 bastion 세션 생성이 안되는 이슈가 있었습니다. 원인은 인스턴스의 우분투 버전이었고, 다운그레이드로 해결했습니다.(24.02 -> 22.04)

### 채팅방 생성 전략 및 로직 구현

- **채팅방 ID 생성**: MongoDB 환경에서 여러 서버 인스턴스 간의 ID 충돌을 방지하기 위해, 별도의 시퀀스 컬렉션을 사용하는 카운터 패턴을 구현했습니다. `SequenceGeneratorService`는 MongoDB의 원자적 연산인 `findAndModify`를 사용하여 동시성 이슈 없이 안전하게 순차적인 `Long` 타입 ID를 발급합니다.
- **채팅방 생성 로직 중앙화**: 채팅방 생성의 모든 책임을 갖는 `ChatRoomService`를 구현했습니다. 이 서비스는 ID를 발급받고, 멤버 목록을 구성하며, 최종적으로 `ChatRoom` 엔티티를 생성 및 저장하는 역할을 전담합니다.
- **사용자 주도 생성**: `ChatRoomController`와 `POST /api/v1/chat/rooms` API를 구현하여, 인증된 사용자가 직접 다른 사용자들을 초대해 채팅방을 만들 수 있도록 했습니다. 기존 프로젝트의 `SuccessResponse` 형식, 에러 처리, Swagger 문서화 컨벤션을 모두 준수했습니다.
- **시스템 주도 생성 (Strategy Pattern 적용)**: "매칭 후 채팅방 자동 생성"과 같은 시스템 주도 시나리오를 위해, 매칭 로직을 `MatchingStrategy` 인터페이스로 추상화했습니다.
    - `MatchingService`는 특정 매칭 알고리즘(`RandomMatchingStrategy` 등)에 의존하지 않고, 주입된 `MatchingStrategy`를 실행합니다.
    - 매칭이 성공하면, `MatchingService`는 중앙화된 `ChatRoomService`를 호출하여 채팅방을 생성합니다. 이로써 채팅방 생성 로직을 재사용하고, 향후 새로운 매칭 전략을 쉽게 추가할 수 있는 확장성 있는 구조를 완성했습니다.
    - 현재는 하드코딩되어 있어, 추후 매칭 알고리즘 구현 때 추가할 예정입니다.
- **WebSocket 컨슈머 구현**: 현재 구현된 RabbitMQ Publisher에 발행된 메시지를 구독(Subscribe)하여 클라이언트에게 실시간으로 전달하는 WebSocket 서버(Consumer)를 구현하였습니다. 해당 코드는 채팅서버 레포에 있습니다.

## 📌 차후 계획

- **신규 매칭 전략 추가**: 현재는 `RandomMatchingStrategy`만 구현되어 있으나, 사용자의 관심사나 티어(Tier) 기반의 `InterestBasedMatchingStrategy` 등 새로운 매칭 전략 구현체를 추가할 예정입니다.

## 📌 테스트 케이스

- [x] 기능 정상 동작 확인
- [x] 새로운 의존성 추가 여부 확인 (`build.gradle`에 `spring-boot-starter-amqp` 추가됨)
- [x] 코드 스타일 및 컨벤션 준수 확인
- [x] 기존 테스트 통과 여부 확인

- **단위 테스트**: `ChatService`와 `ChatMessagePublisher`의 비즈니스 로직을 검증하기 위해 Mockito를 사용하여 단위 테스트를 작성했습니다. Repository와 외부 서비스(`RabbitTemplate`)를 Mocking하여 순수 로직의 정확성을 검증했습니다.
- **API 테스트**: Postman을 사용하여 신규 API 엔드포인트(`POST /api/v1/chat/rooms`, `POST /api/v1/matches`)가 인증, 요청/응답 형식, 에러 처리 등 명세에 따라 올바르게 동작하는 것을 확인했습니다.

Closes #235, #237, #236