### PR TITLE
[Fix/Refactor] 회원가입 플로우 오류 수정 및 API 응답 형식 개선

### DIFF
--- a/src/main/java/synapps/resona/api/chat/code/ChatSuccessCode.java
+++ b/src/main/java/synapps/resona/api/chat/code/ChatSuccessCode.java
@@ -4,9 +4,9 @@ import org.springframework.http.HttpStatus;
 import synapps.resona.api.global.dto.code.SuccessCode;
 
 public enum ChatSuccessCode implements SuccessCode {
-  MESSAGE_SENT_SUCCESS(HttpStatus.CREATED, "메시지 전송에 성공하였습니다."),
-  GET_MESSAGES_SUCCESS(HttpStatus.OK, "메시지 목록 조회에 성공하였습니다."),
-  ROOM_CREATED_SUCCESS(HttpStatus.CREATED, "채팅방 생성에 성공하였습니다.");
+  MESSAGE_SENT_SUCCESS(HttpStatus.CREATED, "Message sent successfully."),
+  GET_MESSAGES_SUCCESS(HttpStatus.OK, "Successfully retrieved message list."),
+  ROOM_CREATED_SUCCESS(HttpStatus.CREATED, "Chat room created successfully.");
 
   private final HttpStatus status;
   private final String message;

--- a/src/main/java/synapps/resona/api/external/email/MailController.java
+++ b/src/main/java/synapps/resona/api/external/email/MailController.java
@@ -45,7 +45,7 @@ public class MailController {
   })
   @PostMapping()
   public ResponseEntity<SuccessResponse<HashMap<String, Object>>> sendMail(HttpServletRequest request,
-      @Parameter(description = "인증번호를 받을 이메일 주소", required = true) @RequestParam String mail) throws EmailException {
+      @Parameter(description = "인증번호를 받을 이메일 주소", required = true) @RequestParam String mail) {
     HashMap<String, Object> result = mailService.send(mail);
 
     return ResponseEntity
@@ -61,8 +61,7 @@ public class MailController {
   })
   @PostMapping("/temp-token")
   public ResponseEntity<SuccessResponse<?>> mailCheckAndIssueToken(HttpServletRequest request,
-      @Valid @RequestBody EmailCheckDto emailCheckDto) throws EmailException {
-
+      @Valid @RequestBody EmailCheckDto emailCheckDto) {
     return ResponseEntity
         .status(EmailSuccessCode.EMAIL_VERIFICATION_SUCCESS.getStatus())
         .body(SuccessResponse.of(EmailSuccessCode.EMAIL_VERIFICATION_SUCCESS, createRequestInfo(request.getQueryString()), mailService.verifyMailAndIssueToken(emailCheckDto.getEmail(), emailCheckDto.getNumber())));

--- a/src/main/java/synapps/resona/api/external/email/MailSendService.java
+++ b/src/main/java/synapps/resona/api/external/email/MailSendService.java
@@ -25,7 +25,7 @@ public class MailSendService {
   }
 
   // TODO: 이메일 내용 수정 필요
-  public MimeMessage createMail(String mail) throws EmailException {
+  public MimeMessage createMail(String mail) {
     if (mail == null || mail.isEmpty()) {
       throw new IllegalArgumentException("수신자의 이메일 주소가 유효하지 않습니다.");
     }
@@ -55,18 +55,20 @@ public class MailSendService {
       body += "</div>";
 
       message.setText(body, "UTF-8", "html");
-    } catch (MailSendException | MessagingException e) {
+    } catch (MailSendException e) {
       throw EmailException.emailSendFailed();
+    } catch (MessagingException e) {
+      throw new RuntimeException(e);
     }
     return message;
   }
 
-  public int sendMail(String mail) throws EmailException {
+  public int sendMail(String mail) {
     try {
       MimeMessage message = createMail(mail);
       javaMailSender.send(message);
       return number;
-    } catch (MailException | MessagingException e) {
+    } catch (MailException e) {
       throw EmailException.emailSendFailed();
     }
   }

--- a/src/main/java/synapps/resona/api/external/email/MailService.java
+++ b/src/main/java/synapps/resona/api/external/email/MailService.java
@@ -15,9 +15,9 @@ public class MailService {
   private final RedisService redisService;
   private final TempTokenService tempTokenService;
 
-  public HashMap<String, Object> send(String email) throws EmailException {
+  public HashMap<String, Object> send(String email) {
 
-    redisService.initialize(email); // 이메일 인증이 초기화 된 경우 동작
+    redisService.initialize(email);
 
     HashMap<String, Object> map = new HashMap<>();
     if (!redisService.isEmailSendAvailable(email)) {
@@ -27,7 +27,7 @@ public class MailService {
       throw EmailException.sendTrialExceeded();
     }
 
-    int number = mailSendService.sendMail(email); // 메일 전송
+    int number = mailSendService.sendMail(email);
     redisService.countSend(email);
     redisService.resetEmailCheckCount(email);
     String num = String.valueOf(number);
@@ -39,7 +39,7 @@ public class MailService {
     return map;
   }
 
-  public List<?> verifyMailAndIssueToken(String email, String number) throws EmailException {
+  public List<?> verifyMailAndIssueToken(String email, String number) {
     if (!redisService.isEmailCheckAvailable(email)) {
       throw EmailException.verifyTrialExceeded();
     }

--- a/src/main/java/synapps/resona/api/external/email/RedisService.java
+++ b/src/main/java/synapps/resona/api/external/email/RedisService.java
@@ -47,7 +47,7 @@ public class RedisService {
    * @param email 이메일
    * @return 이메일 검증 가능 여부
    */
-  public boolean isEmailCheckAvailable(String email) throws EmailException {
+  public boolean isEmailCheckAvailable(String email) {
     String countKey = email + NUMBER_CHECK_COUNT_KEY;
     ValueOperations<String, Object> valOperations = redisNumberCheckTemplate.opsForValue();
 
@@ -119,7 +119,7 @@ public class RedisService {
    * @return 이메일에 매칭되는 코드 번호
    * @throws EmailException 인증시간이 넘어가면 예외 발생
    */
-  public String getCode(String email) throws EmailException {
+  public String getCode(String email) {
     ValueOperations<String, Object> valOperations = redisEmailSendTemplate.opsForValue();
     Object code = valOperations.get(email);
 

--- a/src/main/java/synapps/resona/api/external/email/code/EmailErrorCode.java
+++ b/src/main/java/synapps/resona/api/external/email/code/EmailErrorCode.java
@@ -24,8 +24,11 @@ public enum EmailErrorCode implements ErrorCode {
     this.message = message;
   }
 
-  public static EmailErrorCode fromErrorCode(String errorCode) {
-    return Arrays.stream(EmailErrorCode.values()).filter(error-> error.code.equals(errorCode)).findFirst().get();
+  public static EmailErrorCode fromErrorCode(String customCode) {
+    return Arrays.stream(EmailErrorCode.values())
+        .filter(e -> e.getCustomCode().equals(customCode))
+        .findFirst()
+        .orElse(EmailErrorCode.EMAIL_SEND_FAILED);
   }
 
   @Override

--- a/src/main/java/synapps/resona/api/external/email/code/EmailErrorCode.java
+++ b/src/main/java/synapps/resona/api/external/email/code/EmailErrorCode.java
@@ -1,5 +1,6 @@
 package synapps.resona.api.external.email.code;
 
+import java.util.Arrays;
 import org.springframework.http.HttpStatus;
 import synapps.resona.api.global.dto.code.ErrorCode;
 
@@ -21,6 +22,10 @@ public enum EmailErrorCode implements ErrorCode {
     this.code = code;
     this.status = status;
     this.message = message;
+  }
+
+  public static EmailErrorCode fromErrorCode(String errorCode) {
+    return Arrays.stream(EmailErrorCode.values()).filter(error-> error.code.equals(errorCode)).findFirst().get();
   }
 
   @Override

--- a/src/main/java/synapps/resona/api/external/email/code/EmailSuccessCode.java
+++ b/src/main/java/synapps/resona/api/external/email/code/EmailSuccessCode.java
@@ -5,8 +5,8 @@ import synapps.resona.api.global.dto.code.SuccessCode;
 
 public enum EmailSuccessCode implements SuccessCode {
 
-  SEND_VERIFICATION_EMAIL_SUCCESS(HttpStatus.OK, "인증 이메일 발송에 성공하였습니다."),
-  EMAIL_VERIFICATION_SUCCESS(HttpStatus.OK, "이메일 인증에 성공하였습니다.");
+  SEND_VERIFICATION_EMAIL_SUCCESS(HttpStatus.OK, "Verification email sent successfully."),
+  EMAIL_VERIFICATION_SUCCESS(HttpStatus.OK, "Email verification successful.");
 
   private final HttpStatus status;
   private final String message;

--- a/src/main/java/synapps/resona/api/external/email/exception/EmailException.java
+++ b/src/main/java/synapps/resona/api/external/email/exception/EmailException.java
@@ -5,24 +5,15 @@ import lombok.Getter;
 import org.springframework.http.HttpStatus;
 import synapps.resona.api.external.email.code.EmailErrorCode;
 import synapps.resona.api.global.error.GlobalErrorCode;
+import synapps.resona.api.global.error.exception.BaseException;
 
 @Getter
-public class EmailException extends MessagingException {
-
-  private final HttpStatus status;
-  private final String errorCode;
+public class EmailException extends BaseException {
 
   private Integer mailCheckCountLeft;
 
   public EmailException(String message, HttpStatus status, String errorCode) {
-    super(message);
-    this.status = status;
-    this.errorCode = errorCode;
-  }
-
-  private EmailException(HttpStatus status, String errorCode) {
-    this.status = status;
-    this.errorCode = errorCode;
+    super(message, status, errorCode);
   }
 
   private static EmailException of(EmailErrorCode errorCode) {

--- a/src/main/java/synapps/resona/api/external/file/code/FileSuccessCode.java
+++ b/src/main/java/synapps/resona/api/external/file/code/FileSuccessCode.java
@@ -5,9 +5,9 @@ import synapps.resona.api.global.dto.code.SuccessCode;
 
 public enum FileSuccessCode implements SuccessCode {
 
-  UPLOAD_FILE_SUCCESS(HttpStatus.OK, "파일 업로드에 성공하였습니다."),
-  UPLOAD_MULTIPLE_FILES_SUCCESS(HttpStatus.OK, "다중 파일 업로드에 성공하였습니다."),
-  FINALIZE_FILE_SUCCESS(HttpStatus.OK, "파일 이동 및 최종 처리에 성공하였습니다.");
+  UPLOAD_FILE_SUCCESS(HttpStatus.OK, "File uploaded successfully."),
+  UPLOAD_MULTIPLE_FILES_SUCCESS(HttpStatus.OK, "Multiple files uploaded successfully."),
+  FINALIZE_FILE_SUCCESS(HttpStatus.OK, "File moved and finalized successfully.");
 
   private final HttpStatus status;
   private final String message;

--- a/src/main/java/synapps/resona/api/global/config/security/SecurityConfig.java
+++ b/src/main/java/synapps/resona/api/global/config/security/SecurityConfig.java
@@ -80,7 +80,8 @@ public class SecurityConfig {
       "/storage",
       "/storage/finalize",
       "/member/password",
-      "/member/join"
+      "/member/join",
+      "/profile/duplicate-tag"
   };
 
   /*

--- a/src/main/java/synapps/resona/api/global/handler/GlobalExceptionHandler.java
+++ b/src/main/java/synapps/resona/api/global/handler/GlobalExceptionHandler.java
@@ -66,14 +66,17 @@ public class GlobalExceptionHandler {
 
   @ExceptionHandler(EmailException.class)
   public ResponseEntity<?> handleEmailException(EmailException ex, HttpServletRequest request) {
+    logger.error("EmailException: code={}, message={}", ex.getErrorCode(), ex.getMessage(), ex);
     RequestInfo requestInfo = createRequestInfo(request);
-    if (ex.getErrorCode().equals(EmailErrorCode.INVALID_EMAIL_CODE.getCustomCode())) {
-      EmailCheckExceptionDto body = new EmailCheckExceptionDto(ex.getMessage(),
-          ex.getMailCheckCountLeft());
-      return createErrorResponse(EmailErrorCode.INVALID_EMAIL_CODE, requestInfo, body);
+
+    EmailErrorCode errorCode = EmailErrorCode.fromErrorCode(ex.getErrorCode());
+
+    if (errorCode == EmailErrorCode.INVALID_EMAIL_CODE) {
+      EmailCheckExceptionDto body = new EmailCheckExceptionDto(ex.getMessage(), ex.getMailCheckCountLeft());
+      return createErrorResponse(errorCode, requestInfo, body);
     }
-    logger.error(ex.getMessage(), ex);
-    return createErrorResponse(GlobalErrorCode.INTERNAL_SERVER_ERROR, requestInfo);
+
+    return createErrorResponse(errorCode, requestInfo);
   }
 
   @ExceptionHandler(AuthException.class)

--- a/src/main/java/synapps/resona/api/global/handler/GlobalExceptionHandler.java
+++ b/src/main/java/synapps/resona/api/global/handler/GlobalExceptionHandler.java
@@ -80,10 +80,13 @@ public class GlobalExceptionHandler {
   }
 
   @ExceptionHandler(AuthException.class)
-  public ResponseEntity<?> handleAuthException(AuthException ex, HttpServletRequest request) { // 파라미터 타입을 AuthException으로 변경
-    logger.error(ex.getMessage(), ex);
+  public ResponseEntity<ErrorResponse<String>> handleAuthException(AuthException ex, HttpServletRequest request) {
+    logger.error("AuthException: code={}, message={}", ex.getErrorCode(), ex.getMessage(), ex);
     RequestInfo requestInfo = createRequestInfo(request);
-    return createErrorResponse(GlobalErrorCode.INTERNAL_SERVER_ERROR, requestInfo);
+
+    AuthErrorCode errorCode = AuthErrorCode.fromCustomCode(ex.getErrorCode());
+
+    return createErrorResponse(errorCode, requestInfo, errorCode.getMessage());
   }
 
   @ExceptionHandler({AuthenticationException.class, BadCredentialsException.class})

--- a/src/main/java/synapps/resona/api/matching/code/MatchingSuccessCode.java
+++ b/src/main/java/synapps/resona/api/matching/code/MatchingSuccessCode.java
@@ -4,7 +4,7 @@ import org.springframework.http.HttpStatus;
 import synapps.resona.api.global.dto.code.SuccessCode;
 
 public enum MatchingSuccessCode implements SuccessCode {
-  MATCHING_SUCCESS(HttpStatus.CREATED, "매칭에 성공하고 채팅방을 생성했습니다.");
+  MATCHING_SUCCESS(HttpStatus.CREATED, "Matching successful and chat room created.");
 
   private final HttpStatus status;
   private final String message;

--- a/src/main/java/synapps/resona/api/member/code/AuthErrorCode.java
+++ b/src/main/java/synapps/resona/api/member/code/AuthErrorCode.java
@@ -1,5 +1,6 @@
 package synapps.resona.api.member.code;
 
+import java.util.Arrays;
 import org.springframework.http.HttpStatus;
 import synapps.resona.api.global.dto.code.ErrorCode;
 
@@ -29,6 +30,13 @@ public enum AuthErrorCode implements ErrorCode {
     this.code = code;
     this.status = status;
     this.message = message;
+  }
+
+  public static AuthErrorCode fromCustomCode(String code) {
+    return Arrays.stream(AuthErrorCode.values())
+        .filter(e -> e.getCustomCode().equals(code))
+        .findFirst()
+        .orElse(UNAUTHORIZED);
   }
 
   @Override

--- a/src/main/java/synapps/resona/api/member/code/MemberSuccessCode.java
+++ b/src/main/java/synapps/resona/api/member/code/MemberSuccessCode.java
@@ -6,44 +6,44 @@ import synapps.resona.api.global.dto.code.SuccessCode;
 public enum MemberSuccessCode implements SuccessCode {
 
   // Auth
-  LOGIN_SUCCESS(HttpStatus.OK, "로그인에 성공하였습니다."),
-  APPLE_LOGIN_SUCCESS(HttpStatus.OK, "애플 로그인에 성공하였습니다."),
-  TOKEN_REFRESH_SUCCESS(HttpStatus.OK, "토큰 재발급에 성공하였습니다."),
-  MEMBER_INFO_SUCCESS(HttpStatus.OK, "회원 정보 조회에 성공하였습니다."),
+  LOGIN_SUCCESS(HttpStatus.OK, "Login successful."),
+  APPLE_LOGIN_SUCCESS(HttpStatus.OK, "Apple login successful."),
+  TOKEN_REFRESH_SUCCESS(HttpStatus.OK, "Token refreshed successfully."),
+  MEMBER_INFO_SUCCESS(HttpStatus.OK, "Successfully retrieved member information."),
 
   // Follow
-  FOLLOW_SUCCESS(HttpStatus.OK, "팔로우에 성공하였습니다."),
-  UNFOLLOW_SUCCESS(HttpStatus.OK, "언팔로우에 성공하였습니다."),
-  GET_FOLLOWERS_SUCCESS(HttpStatus.OK, "팔로워 목록 조회에 성공하였습니다."),
-  GET_FOLLOWINGS_SUCCESS(HttpStatus.OK, "팔로잉 목록 조회에 성공하였습니다."),
+  FOLLOW_SUCCESS(HttpStatus.OK, "Follow successful."),
+  UNFOLLOW_SUCCESS(HttpStatus.OK, "Unfollow successful."),
+  GET_FOLLOWERS_SUCCESS(HttpStatus.OK, "Successfully retrieved follower list."),
+  GET_FOLLOWINGS_SUCCESS(HttpStatus.OK, "Successfully retrieved following list."),
 
   // Member
-  JOIN_SUCCESS(HttpStatus.CREATED, "회원가입에 성공하였습니다."),
-  GET_MY_INFO_SUCCESS(HttpStatus.OK, "내 정보 조회에 성공하였습니다."),
-  GET_MEMBER_DETAIL_SUCCESS(HttpStatus.OK, "회원 상세 정보 조회에 성공하였습니다."),
-  PASSWORD_CHANGE_SUCCESS(HttpStatus.OK, "비밀번호 변경에 성공하였습니다."),
-  DELETE_USER_SUCCESS(HttpStatus.OK, "회원 탈퇴에 성공하였습니다."),
+  JOIN_SUCCESS(HttpStatus.CREATED, "Sign up successful."),
+  GET_MY_INFO_SUCCESS(HttpStatus.OK, "Successfully retrieved my information."),
+  GET_MEMBER_DETAIL_SUCCESS(HttpStatus.OK, "Successfully retrieved member details."),
+  PASSWORD_CHANGE_SUCCESS(HttpStatus.OK, "Password changed successfully."),
+  DELETE_USER_SUCCESS(HttpStatus.OK, "Member deleted successfully."),
 
   // Member Details
-  REGISTER_DETAILS_SUCCESS(HttpStatus.CREATED, "개인정보 등록에 성공하였습니다."),
-  GET_DETAILS_SUCCESS(HttpStatus.OK, "개인정보 조회에 성공하였습니다."),
-  EDIT_DETAILS_SUCCESS(HttpStatus.OK, "개인정보 수정에 성공하였습니다."),
-  DELETE_DETAILS_SUCCESS(HttpStatus.OK, "개인정보 삭제에 성공하였습니다."),
+  REGISTER_DETAILS_SUCCESS(HttpStatus.CREATED, "Personal information registered successfully."),
+  GET_DETAILS_SUCCESS(HttpStatus.OK, "Successfully retrieved personal information."),
+  EDIT_DETAILS_SUCCESS(HttpStatus.OK, "Personal information updated successfully."),
+  DELETE_DETAILS_SUCCESS(HttpStatus.OK, "Personal information deleted successfully."),
 
   // Notification
-  REGISTER_FCM_TOKEN_SUCCESS(HttpStatus.OK, "FCM 토큰 등록에 성공하였습니다."),
-  GET_NOTIFICATION_SETTING_SUCCESS(HttpStatus.OK, "알림 설정 조회에 성공하였습니다."),
-  UPDATE_NOTIFICATION_SETTING_SUCCESS(HttpStatus.OK, "알림 설정 수정에 성공하였습니다."),
-  GET_NOTIFICATIONS_SUCCESS(HttpStatus.OK, "알림 목록 조회에 성공하였습니다."),
-  READ_NOTIFICATION_SUCCESS(HttpStatus.OK, "알림 읽음 처리에 성공하였습니다."),
-  DELETE_NOTIFICATION_SUCCESS(HttpStatus.OK, "알림 삭제에 성공하였습니다."),
+  REGISTER_FCM_TOKEN_SUCCESS(HttpStatus.OK, "FCM token registered successfully."),
+  GET_NOTIFICATION_SETTING_SUCCESS(HttpStatus.OK, "Successfully retrieved notification settings."),
+  UPDATE_NOTIFICATION_SETTING_SUCCESS(HttpStatus.OK, "Notification settings updated successfully."),
+  GET_NOTIFICATIONS_SUCCESS(HttpStatus.OK, "Successfully retrieved notification list."),
+  READ_NOTIFICATION_SUCCESS(HttpStatus.OK, "Notification read successfully."),
+  DELETE_NOTIFICATION_SUCCESS(HttpStatus.OK, "Notification deleted successfully."),
 
   // Profile
-  REGISTER_PROFILE_SUCCESS(HttpStatus.CREATED, "프로필 등록에 성공하였습니다."),
-  GET_PROFILE_SUCCESS(HttpStatus.OK, "프로필 조회에 성공하였습니다."),
-  EDIT_PROFILE_SUCCESS(HttpStatus.OK, "프로필 수정에 성공하였습니다."),
-  DELETE_PROFILE_SUCCESS(HttpStatus.OK, "프로필 삭제에 성공하였습니다."),
-  CHECK_TAG_DUPLICATE_SUCCESS(HttpStatus.OK, "태그 중복 검사에 성공하였습니다.");
+  REGISTER_PROFILE_SUCCESS(HttpStatus.CREATED, "Profile registered successfully."),
+  GET_PROFILE_SUCCESS(HttpStatus.OK, "Successfully retrieved profile."),
+  EDIT_PROFILE_SUCCESS(HttpStatus.OK, "Profile updated successfully."),
+  DELETE_PROFILE_SUCCESS(HttpStatus.OK, "Profile deleted successfully."),
+  CHECK_TAG_DUPLICATE_SUCCESS(HttpStatus.OK, "Tag duplication check successful.");
 
 
   private final HttpStatus status;

--- a/src/main/java/synapps/resona/api/member/dto/response/MemberInfoDto.java
+++ b/src/main/java/synapps/resona/api/member/dto/response/MemberInfoDto.java
@@ -97,7 +97,9 @@ public class MemberInfoDto {
 
   private static Set<String> safeToStringSet(Set<Language> languages) {
     return Optional.ofNullable(languages)
-        .map(set -> set.stream().map(Language::toString).collect(Collectors.toSet()))
+        .map(langSet -> langSet.stream()
+            .map(Language::getCode)
+            .collect(Collectors.toSet()))
         .orElse(Set.of());
   }
 }

--- a/src/main/java/synapps/resona/api/socialMedia/code/SocialSuccessCode.java
+++ b/src/main/java/synapps/resona/api/socialMedia/code/SocialSuccessCode.java
@@ -6,65 +6,65 @@ import synapps.resona.api.global.dto.code.SuccessCode;
 public enum SocialSuccessCode implements SuccessCode {
 
   // Feed
-  REGISTER_FEED_SUCCESS(HttpStatus.CREATED, "피드 등록에 성공하였습니다."),
-  GET_FEED_SUCCESS(HttpStatus.OK, "피드 조회에 성공하였습니다."),
-  GET_FEEDS_SUCCESS(HttpStatus.OK, "피드 목록 조회에 성공하였습니다."),
-  GET_MEMBER_FEEDS_SUCCESS(HttpStatus.OK, "사용자 피드 목록 조회에 성공하였습니다."),
-  EDIT_FEED_SUCCESS(HttpStatus.OK, "피드 수정에 성공하였습니다."),
-  DELETE_FEED_SUCCESS(HttpStatus.OK, "피드 삭제에 성공하였습니다."),
+  REGISTER_FEED_SUCCESS(HttpStatus.CREATED, "Feed registered successfully."),
+  GET_FEED_SUCCESS(HttpStatus.OK, "Successfully retrieved feed."),
+  GET_FEEDS_SUCCESS(HttpStatus.OK, "Successfully retrieved feed list."),
+  GET_MEMBER_FEEDS_SUCCESS(HttpStatus.OK, "Successfully retrieved user feed list."),
+  EDIT_FEED_SUCCESS(HttpStatus.OK, "Feed updated successfully."),
+  DELETE_FEED_SUCCESS(HttpStatus.OK, "Feed deleted successfully."),
 
   // Feed Like
-  LIKE_FEED_SUCCESS(HttpStatus.OK, "피드 좋아요 처리에 성공하였습니다."),
-  UNLIKE_FEED_SUCCESS(HttpStatus.OK, "피드 좋아요 취소에 성공하였습니다."),
+  LIKE_FEED_SUCCESS(HttpStatus.OK, "Feed liked successfully."),
+  UNLIKE_FEED_SUCCESS(HttpStatus.OK, "Feed unliked successfully."),
 
   // Comment Like
-  LIKE_COMMENT_SUCCESS(HttpStatus.OK, "댓글 좋아요 처리에 성공하였습니다."),
-  UNLIKE_COMMENT_SUCCESS(HttpStatus.OK, "댓글 좋아요 취소에 성공하였습니다."),
+  LIKE_COMMENT_SUCCESS(HttpStatus.OK, "Comment liked successfully."),
+  UNLIKE_COMMENT_SUCCESS(HttpStatus.OK, "Comment unliked successfully."),
 
   // Reply Like
-  LIKE_REPLY_SUCCESS(HttpStatus.OK, "대댓글 좋아요 처리에 성공하였습니다."),
-  UNLIKE_REPLY_SUCCESS(HttpStatus.OK, "대댓글 좋아요 취소에 성공하였습니다."),
+  LIKE_REPLY_SUCCESS(HttpStatus.OK, "Reply liked successfully."),
+  UNLIKE_REPLY_SUCCESS(HttpStatus.OK, "Reply unliked successfully."),
 
 
   // Scrap
-  SCRAP_SUCCESS(HttpStatus.OK, "스크랩에 성공하였습니다."),
-  CANCEL_SCRAP_SUCCESS(HttpStatus.OK, "스크랩 취소에 성공하였습니다."),
-  GET_SCRAP_SUCCESS(HttpStatus.OK, "스크랩 조회에 성공하였습니다."),
-  GET_SCRAPS_SUCCESS(HttpStatus.OK, "스크랩 목록 조회에 성공하였습니다."),
+  SCRAP_SUCCESS(HttpStatus.OK, "Scrap successful."),
+  CANCEL_SCRAP_SUCCESS(HttpStatus.OK, "Scrap canceled successfully."),
+  GET_SCRAP_SUCCESS(HttpStatus.OK, "Successfully retrieved scrap."),
+  GET_SCRAPS_SUCCESS(HttpStatus.OK, "Successfully retrieved scrap list."),
 
   // Comment
-  REGISTER_COMMENT_SUCCESS(HttpStatus.CREATED, "댓글 등록에 성공하였습니다."),
-  EDIT_COMMENT_SUCCESS(HttpStatus.OK, "댓글 수정에 성공하였습니다."),
-  DELETE_COMMENT_SUCCESS(HttpStatus.OK, "댓글 삭제에 성공하였습니다."),
-  GET_COMMENT_SUCCESS(HttpStatus.OK, "댓글 조회에 성공하였습니다."),
-  GET_COMMENTS_SUCCESS(HttpStatus.OK, "댓글 목록 조회에 성공하였습니다."),
+  REGISTER_COMMENT_SUCCESS(HttpStatus.CREATED, "Comment registered successfully."),
+  EDIT_COMMENT_SUCCESS(HttpStatus.OK, "Comment updated successfully."),
+  DELETE_COMMENT_SUCCESS(HttpStatus.OK, "Comment deleted successfully."),
+  GET_COMMENT_SUCCESS(HttpStatus.OK, "Successfully retrieved comment."),
+  GET_COMMENTS_SUCCESS(HttpStatus.OK, "Successfully retrieved comment list."),
 
   // Reply
-  REGISTER_REPLY_SUCCESS(HttpStatus.CREATED, "답글 등록에 성공하였습니다."),
-  GET_REPLY_SUCCESS(HttpStatus.OK, "답글 조회에 성공하였습니다."),
-  GET_REPLIES_SUCCESS(HttpStatus.OK, "답글 목록 조회에 성공하였습니다."), // 답글 목록 조회 성공 코드 추가
-  EDIT_REPLY_SUCCESS(HttpStatus.OK, "답글 수정에 성공하였습니다."),
-  DELETE_REPLY_SUCCESS(HttpStatus.OK, "답글 삭제에 성공하였습니다."),
+  REGISTER_REPLY_SUCCESS(HttpStatus.CREATED, "Reply registered successfully."),
+  GET_REPLY_SUCCESS(HttpStatus.OK, "Successfully retrieved reply."),
+  GET_REPLIES_SUCCESS(HttpStatus.OK, "Successfully retrieved reply list."),
+  EDIT_REPLY_SUCCESS(HttpStatus.OK, "Reply updated successfully."),
+  DELETE_REPLY_SUCCESS(HttpStatus.OK, "Reply deleted successfully."),
 
   // Report
-  REPORT_FEED_SUCCESS(HttpStatus.OK, "피드 신고가 접수되었습니다."),
-  REPORT_COMMENT_SUCCESS(HttpStatus.OK, "댓글 신고가 접수되었습니다."),
-  REPORT_REPLY_SUCCESS(HttpStatus.OK, "대댓글 신고가 접수되었습니다."),
+  REPORT_FEED_SUCCESS(HttpStatus.OK, "Feed reported successfully."),
+  REPORT_COMMENT_SUCCESS(HttpStatus.OK, "Comment reported successfully."),
+  REPORT_REPLY_SUCCESS(HttpStatus.OK, "Reply reported successfully."),
 
   // Mention
-  REGISTER_MENTION_SUCCESS(HttpStatus.CREATED, "멘션 등록에 성공하였습니다."),
-  GET_MENTION_SUCCESS(HttpStatus.OK, "멘션 조회에 성공하였습니다."),
-  DELETE_MENTION_SUCCESS(HttpStatus.OK, "멘션 삭제에 성공하였습니다."),
+  REGISTER_MENTION_SUCCESS(HttpStatus.CREATED, "Mention registered successfully."),
+  GET_MENTION_SUCCESS(HttpStatus.OK, "Successfully retrieved mention."),
+  DELETE_MENTION_SUCCESS(HttpStatus.OK, "Mention deleted successfully."),
 
   // Block
-  BLOCK_SUCCESS(HttpStatus.CREATED, "사용자 차단에 성공하였습니다."),
-  UNBLOCK_SUCCESS(HttpStatus.OK, "사용자 차단 해제에 성공하였습니다."),
-  BLOCK_LIST_SUCCESS(HttpStatus.OK, "차단한 사용자 조회에 성공하였습니다."),
+  BLOCK_SUCCESS(HttpStatus.CREATED, "User blocked successfully."),
+  UNBLOCK_SUCCESS(HttpStatus.OK, "User unblocked successfully."),
+  BLOCK_LIST_SUCCESS(HttpStatus.OK, "Successfully retrieved blocked user list."),
 
   // Hide
-  HIDE_FEED_SUCCESS(HttpStatus.OK, "피드 숨김에 성공하였습니다."),
-  HIDE_COMMENT_SUCCESS(HttpStatus.OK, "댓글 숨김에 성공하였습니다."),
-  HIDE_REPLY_SUCCESS(HttpStatus.OK, "대댓글 숨김에 성공하였습니다.");
+  HIDE_FEED_SUCCESS(HttpStatus.OK, "Feed hidden successfully."),
+  HIDE_COMMENT_SUCCESS(HttpStatus.OK, "Comment hidden successfully."),
+  HIDE_REPLY_SUCCESS(HttpStatus.OK, "Reply hidden successfully.");
 
 
   private final HttpStatus status;

--- a/src/main/java/synapps/resona/api/socialMedia/feed/dto/FeedDto.java
+++ b/src/main/java/synapps/resona/api/socialMedia/feed/dto/FeedDto.java
@@ -18,7 +18,7 @@ public class FeedDto {
   private final Long feedId;
   private final SocialMemberDto author;
   private FeedCategory category;
-  private Language language;
+  private String languageCode;
   private final String content;
   private final List<FeedMediaDto> images;
 
@@ -41,6 +41,7 @@ public class FeedDto {
         .author(SocialMemberDto.from(feed.getMember()))
         .content(feed.getContent())
         .category(feed.getCategory())
+        .languageCode(feed.getLanguage().getCode())
         .likeCount((int) dto.getMetaData().getLikeCount())
         .images(feed.getImages().stream().map(FeedMediaDto::from).toList()) // @BatchSize
         .commentCount((int) dto.getMetaData().getCommentCount())

--- a/src/main/java/synapps/resona/api/socialMedia/feed/dto/request/FeedRequest.java
+++ b/src/main/java/synapps/resona/api/socialMedia/feed/dto/request/FeedRequest.java
@@ -16,5 +16,5 @@ public class FeedRequest {
   private String content;
   private String category;
   private LocationRequest location;
-  private String language;
+  private String languageCode;
 }

--- a/src/main/java/synapps/resona/api/socialMedia/feed/entity/Feed.java
+++ b/src/main/java/synapps/resona/api/socialMedia/feed/entity/Feed.java
@@ -68,15 +68,15 @@ public class Feed extends BaseEntity {
   @Column(name = "category")
   private FeedCategory category;
 
-  private Feed(Member member, String content, String category, String language) {
+  private Feed(Member member, String content, String category, String languageCode) {
     this.member = member;
     this.content = content;
     this.category = FeedCategory.of(category);
-    this.language = Language.of(language);
+    this.language = Language.fromCode(languageCode);
   }
 
-  public static Feed of(Member member, String content, String category, String language) {
-    return new Feed(member, content, category, language);
+  public static Feed of(Member member, String content, String category, String languageCode) {
+    return new Feed(member, content, category, languageCode);
   }
 
   public void updateContent(String content) {

--- a/src/main/java/synapps/resona/api/socialMedia/feed/service/FeedService.java
+++ b/src/main/java/synapps/resona/api/socialMedia/feed/service/FeedService.java
@@ -122,7 +122,7 @@ public class FeedService {
     Member member = memberRepository.findByEmail(email).orElseThrow();
 
     // save feed entity
-    Feed feed = Feed.of(member, feedRequest.getContent(), feedRequest.getCategory(), feedRequest.getLanguage());
+    Feed feed = Feed.of(member, feedRequest.getContent(), feedRequest.getCategory(), feedRequest.getLanguageCode());
     feedRepository.save(feed);
 
     // finalizing feedImages: move buffer bucket images to disk bucket

--- a/src/test/java/synapps/resona/api/socialMedia/feed/controller/FeedControllerResponseTest.java
+++ b/src/test/java/synapps/resona/api/socialMedia/feed/controller/FeedControllerResponseTest.java
@@ -115,7 +115,7 @@ class FeedControllerResponseTest {
     // then
     actions.andExpect(status().isOk())
         .andExpect(jsonPath("$.meta.status").value(200))
-        .andExpect(jsonPath("$.meta.message").value("피드 조회에 성공하였습니다."))
+        .andExpect(jsonPath("$.meta.message").value("Successfully retrieved feed."))
         .andExpect(jsonPath("$.data.feedId").value(feedId))
         .andExpect(jsonPath("$.data.content").value("Feed Content"))
         .andExpect(jsonPath("$.data.likeCount").value(10))
@@ -211,7 +211,7 @@ class FeedControllerResponseTest {
     // then
     actions.andExpect(status().isOk())
         .andExpect(jsonPath("$.meta.status").value(200))
-        .andExpect(jsonPath("$.meta.message").value("피드 삭제에 성공하였습니다."))
+        .andExpect(jsonPath("$.meta.message").value("Feed deleted successfully."))
         // void 응답이므로 data 필드는 null 이거나 존재하지 않음
         .andExpect(jsonPath("$.data").doesNotExist())
         .andDo(print());

--- a/src/test/java/synapps/resona/api/socialMedia/report/controller/ReportControllerTest.java
+++ b/src/test/java/synapps/resona/api/socialMedia/report/controller/ReportControllerTest.java
@@ -78,8 +78,8 @@ class ReportControllerTest {
     // then
     actions.andExpect(status().isOk())
         .andExpect(jsonPath("$.meta.status").value(200))
-        .andExpect(jsonPath("$.meta.message").value("피드 신고가 접수되었습니다."))
-        .andExpect(jsonPath("$.data").doesNotExist()) // Void 응답이므로 data 필드는 없음
+        .andExpect(jsonPath("$.meta.message").value("Feed reported successfully."))
+        .andExpect(jsonPath("$.data").doesNotExist())
         .andDo(print());
   }
 
@@ -102,7 +102,7 @@ class ReportControllerTest {
     // then
     actions.andExpect(status().isOk())
         .andExpect(jsonPath("$.meta.status").value(200))
-        .andExpect(jsonPath("$.meta.message").value("댓글 신고가 접수되었습니다."))
+        .andExpect(jsonPath("$.meta.message").value("Comment reported successfully."))
         .andExpect(jsonPath("$.data").doesNotExist())
         .andDo(print());
   }
@@ -126,7 +126,7 @@ class ReportControllerTest {
     // then
     actions.andExpect(status().isOk())
         .andExpect(jsonPath("$.meta.status").value(200))
-        .andExpect(jsonPath("$.meta.message").value("대댓글 신고가 접수되었습니다."))
+        .andExpect(jsonPath("$.meta.message").value("Reply reported successfully."))
         .andExpect(jsonPath("$.data").doesNotExist())
         .andDo(print());
   }

--- a/src/test/java/synapps/resona/api/socialMedia/restriction/controller/BlockControllerTest.java
+++ b/src/test/java/synapps/resona/api/socialMedia/restriction/controller/BlockControllerTest.java
@@ -75,7 +75,7 @@ class BlockControllerTest {
     // then
     actions.andExpect(status().isCreated())
         .andExpect(jsonPath("$.meta.status").value(201))
-        .andExpect(jsonPath("$.meta.message").value("사용자 차단에 성공하였습니다."))
+        .andExpect(jsonPath("$.meta.message").value("User blocked successfully."))
         .andExpect(jsonPath("$.data").doesNotExist())
         .andDo(print());
   }
@@ -95,7 +95,7 @@ class BlockControllerTest {
     // then
     actions.andExpect(status().isOk())
         .andExpect(jsonPath("$.meta.status").value(200))
-        .andExpect(jsonPath("$.meta.message").value("사용자 차단 해제에 성공하였습니다."))
+        .andExpect(jsonPath("$.meta.message").value("User unblocked successfully."))
         .andExpect(jsonPath("$.data").doesNotExist())
         .andDo(print());
   }
@@ -118,7 +118,7 @@ class BlockControllerTest {
     // then
     actions.andExpect(status().isOk())
         .andExpect(jsonPath("$.meta.status").value(200))
-        .andExpect(jsonPath("$.meta.message").value("차단한 사용자 조회에 성공하였습니다."))
+        .andExpect(jsonPath("$.meta.message").value("Successfully retrieved blocked user list."))
         .andExpect(jsonPath("$.data").isArray())
         .andExpect(jsonPath("$.data.length()").value(2))
         .andExpect(jsonPath("$.data[0].blockId").value(2L))

--- a/src/test/java/synapps/resona/api/socialMedia/restriction/controller/HideControllerTest.java
+++ b/src/test/java/synapps/resona/api/socialMedia/restriction/controller/HideControllerTest.java
@@ -68,7 +68,7 @@ class HideControllerTest {
     // then
     actions.andExpect(status().isOk())
         .andExpect(jsonPath("$.meta.status").value(200))
-        .andExpect(jsonPath("$.meta.message").value("피드 숨김에 성공하였습니다."))
+        .andExpect(jsonPath("$.meta.message").value("Feed hidden successfully."))
         .andExpect(jsonPath("$.data").doesNotExist())
         .andDo(print());
   }
@@ -88,7 +88,7 @@ class HideControllerTest {
     // then
     actions.andExpect(status().isOk())
         .andExpect(jsonPath("$.meta.status").value(200))
-        .andExpect(jsonPath("$.meta.message").value("댓글 숨김에 성공하였습니다."))
+        .andExpect(jsonPath("$.meta.message").value("Comment hidden successfully."))
         .andExpect(jsonPath("$.data").doesNotExist())
         .andDo(print());
   }
@@ -108,7 +108,7 @@ class HideControllerTest {
     // then
     actions.andExpect(status().isOk())
         .andExpect(jsonPath("$.meta.status").value(200))
-        .andExpect(jsonPath("$.meta.message").value("대댓글 숨김에 성공하였습니다."))
+        .andExpect(jsonPath("$.meta.message").value("Reply hidden successfully."))
         .andExpect(jsonPath("$.data").doesNotExist())
         .andDo(print());
   }


### PR DESCRIPTION
## 📌 개요

* 회원가입 과정에서 발생하는 주요 오류들을 수정하고, 데이터 응답 형식을 표준화하여 서비스 안정성과 개발 효율성을 개선합니다.
* **이메일 인증 시도 초과 시 500 에러**, **임시 토큰의 태그 중복 체크 권한 부재**, **언어 필드의 비표준 데이터 형식 반환** 문제를 해결했습니다.

## 🛠️ 작업 내용
- [x] 이메일 인증 시도 초과 시 `429 Too Many Requests` 에러 반환
- [x] `GUEST` 권한으로 태그 중복 체크 API 접근 가능하도록 수정
- [x] `nativeLanguages`, `interestingLanguages` 필드를 언어 코드로 반환하도록 통일
- [x] 관련 이슈 번호 (`#이슈번호`)

### 이메일 인증 예외 처리 변경

* 기존에는 인증 시도 횟수를 초과하면 원인 파악이 어려운 `500 Internal Server Error`가 발생했습니다.
* 이를 클라이언트가 명확하게 원인을 파악하고 후속 조치를 할 수 있도록 `429 Too Many Requests` 상태 코드와 적절한 에러 메시지를 반환하도록 수정했습니다.

### 태그 중복 체크 API 접근 권한 수정

* 회원가입 플로우에서 이메일 인증 직후 발급되는 `GUEST` 권한의 임시 토큰이 태그 중복 체크 API(`.../profile/duplicate-tag`)에 접근하지 못하던 문제를 해결했습니다.
* Spring Security 설정을 변경하여 `GUEST` 역할도 해당 엔드포인트를 호출할 수 있도록 허용했습니다.

### 회원 정보 API 응답 형식 표준화

* 회원 정보를 반환하는 여러 API에서 `nativeLanguages`, `interestingLanguages` 필드가 `"KOREAN"`과 같은 전체 문자열로 반환되고 있었습니다.
* 데이터 일관성 및 효율성을 위해 `"ko"`와 같은 **언어 코드** 형식으로 반환되도록 관련 DTO와 변환 로직을 수정했습니다. 이 변경 사항은 해당 필드를 사용하는 모든 API에 일괄 적용되었습니다.

## 📌 테스트 케이스
- [x] 기능 정상 동작 확인
- [x] 새로운 의존성 추가 여부 확인 (`package.json`, `build.gradle` 등)
- [x] 코드 스타일 및 컨벤션 준수 확인
- [x] 기존 테스트 통과 여부 확인

Closes #267 